### PR TITLE
adr for stratos converted to markdown

### DIFF
--- a/docs/adr/01_drop-consideration-of-stratos.md
+++ b/docs/adr/01_drop-consideration-of-stratos.md
@@ -1,6 +1,6 @@
 # Drop consideration of Stratos as foundation for UI rebuild
 
-Status: Proposed
+Status: Accepted
 
 ## Context and problem statement
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds an architectural decision record explaining why we have decided not to pursue Stratos as a foundation for the future Cloud.gov dashboard.

[You can preview how the markdown will appear here](https://github.com/cloud-gov/cg-ui/blob/599d01ff497128cd1267429e1670091a8b62a06b/docs/adr/01_drop-consideration-of-stratos.md)

Note: using + and - signs in unordered lists was causing them to act indented, so instead I separated out points under each option using the words pros / neutral / cons.

## Security considerations

None of which I am aware.
