### PR TITLE
working example of iron-session with three protected pages

### DIFF
--- a/nextjs/nextjs-site/app/protected-pages/README.md
+++ b/nextjs/nextjs-site/app/protected-pages/README.md
@@ -1,0 +1,16 @@
+# Protected pages with iron session demo
+
+Code adapted from [the app-router-client-component-router-handler-swr](https://github.com/vvo/iron-session/tree/main/examples/next/src/app/app-router-client-component-route-handler-swr) example.
+
+This demo saves a username to a local cookie (you can view it in your browser as `iron-example-app-router-swr`), then demonstrates three different methods of checking if a user is logged in:
+
+- client component
+- via middleware
+- server component
+
+I do not understand all of the moving pieces well just yet.
+
+## A couple notes on changes
+
+I changed the directory name to something a little more straightforward and also converted `.ts` and `.tsx` to `.js` and `.jsx`. I also removed a couple components and styling that felt unnecessary to copy over for our purposes.
+

--- a/nextjs/nextjs-site/app/protected-pages/form.jsx
+++ b/nextjs/nextjs-site/app/protected-pages/form.jsx
@@ -1,0 +1,83 @@
+"use client";
+
+import useSession from "./use-session";
+import { defaultSession } from "./lib";
+
+export function Form() {
+  const { session, isLoading } = useSession();
+
+  if (isLoading) {
+    return <p className="text-lg">Loading...</p>;
+  }
+
+  if (session.isLoggedIn) {
+    return (
+      <>
+        <p className="text-lg">
+          Logged in user: <strong>{session.username}</strong>
+        </p>
+        <LogoutButton />
+      </>
+    );
+  }
+
+  return <LoginForm />;
+}
+
+function LoginForm() {
+  const { login } = useSession();
+
+  return (
+    <form
+      onSubmit={function (event) {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        const username = formData.get("username");
+        // TODO jess what is optimisticData in this context?
+        login(username, {
+          optimisticData: {
+            isLoggedIn: true,
+            username,
+          },
+        });
+      }}
+      method="POST"
+    >
+      <label className="block text-lg">
+        <span>Username</span>
+        <input
+          type="text"
+          name="username"
+          placeholder=""
+          defaultValue="Alison"
+          required
+          // for demo purposes, disabling autocomplete 1password here
+          autoComplete="off"
+          data-1p-ignore
+        />
+      </label>
+      <div>
+        <input type="submit" value="Login" />
+      </div>
+    </form>
+  );
+}
+
+function LogoutButton() {
+  const { logout } = useSession();
+
+  return (
+    <p>
+      <button
+        onClick={(event) => {
+          event.preventDefault();
+          logout(null, {
+            optimisticData: defaultSession,
+          });
+        }}
+      >
+        Logout
+      </button>
+    </p>
+  );
+}

--- a/nextjs/nextjs-site/app/protected-pages/lib.js
+++ b/nextjs/nextjs-site/app/protected-pages/lib.js
@@ -1,0 +1,18 @@
+export const defaultSession = {
+  username: "",
+  isLoggedIn: false
+}
+
+export const sessionOptions = {
+  password: "complex_password_at_least_32_characters_long",
+  cookieName: "iron-example-app-router-swr",
+  cookieOptions: {
+    // secure only works in `https` environments
+    // if your localhost is not on `https`, then use: `secure: process.env.NODE_ENV === "production"`
+    secure: process.env.NODE_ENV === "production"
+  }
+}
+
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/nextjs/nextjs-site/app/protected-pages/page.jsx
+++ b/nextjs/nextjs-site/app/protected-pages/page.jsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { Metadata } from "next";
+import { Form } from "./form";
+
+export const metadata = {
+  title: "iron-session example",
+};
+
+export default function AppRouterSWR() {
+  return (
+    <main className="p-10 space-y-5">
+      <h1>Iron session example</h1>
+
+      <p className="italic max-w-xl">
+        <u>How to test</u>: Login and refresh the page to see iron-session in
+        action. Bonus: open multiple tabs to see the state being reflected by
+        SWR automatically.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 p-10 border border-slate-500 rounded-md max-w-xl">
+        <Form />
+        <div className="space-y-2">
+          <hr />
+          <p>
+            The following pages are protected and will redirect back here if
+            you&apos;re not logged in:
+          </p>
+          {/* convert the following paragraphs into a ul li */}
+          <ul className="list-disc list-inside">
+            <li>
+              <Link
+                href="/protected-pages/protected-client"
+              >
+                Protected page via client component →
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/protected-pages/protected-server"
+                // required to avoid caching issues when navigating between tabs/windows
+                prefetch={false}
+              >
+                Protected page via server component →
+              </Link>{" "}
+            </li>
+            <li>
+              <Link
+                href="/protected-pages/protected-middleware"
+              >
+                Protected page via middleware →
+              </Link>{" "}
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <p>Get the code at <a href="https://github.com/vvo/iron-session/tree/main/examples/next/src/app/app-router-client-component-route-handler-swr">iron-session/examples</a></p>
+      <HowItWorks />
+    </main>
+  );
+}
+
+function HowItWorks() {
+  return (
+    <details className="max-w-2xl space-y-4">
+      <summary className="cursor-pointer">How it works</summary>
+
+      <ol className="list-decimal list-inside">
+        <li>
+          During login, the form is submitted with SWR&apos;s{" "}
+          <a
+            href="https://swr.vercel.app/docs/mutation#useswrmutation"
+          >
+            useSWRMutation
+          </a>
+          . This makes a POST /session request using fetch.
+        </li>
+        <li>
+          {" "}
+          During logout, the form is submitted with SWR&apos;s{" "}
+          <a
+            href="https://swr.vercel.app/docs/mutation#useswrmutation"
+          >
+            useSWRMutation
+          </a>
+          . This makes a DELETE /session request using fetch.
+        </li>
+        <li>
+          In all other places, the content of the session is optimistally
+          rendered using the most recent value, and never gets outdated. This is
+          automatically handled by SWR using mutations and revalidation.
+        </li>
+      </ol>
+    </details>
+  );
+}

--- a/nextjs/nextjs-site/app/protected-pages/protected-client/page.jsx
+++ b/nextjs/nextjs-site/app/protected-pages/protected-client/page.jsx
@@ -1,0 +1,58 @@
+"use client";
+
+import useSession from "../use-session";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function ProtectedClient() {
+  return (
+    <main className="p-10 space-y-5">
+      <h1>Protected client page</h1>
+      <Content />
+      <p>
+        <Link
+          href="/protected-pages"
+        >
+          ← Back
+        </Link>
+      </p>
+    </main>
+  );
+}
+
+function Content() {
+  const { session, isLoading } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !session.isLoggedIn) {
+      router.replace("/protected-pages");
+    }
+  }, [isLoading, session.isLoggedIn, router]);
+
+  if (isLoading) {
+    return <p className="text-lg">Loading...</p>;
+  }
+
+  return (
+    <div className="max-w-xl space-y-2">
+      <p>
+        Hello <strong>{session.username}!</strong>
+      </p>
+      <p>
+        This page is protected and can only be accessed if you are logged in.
+        Otherwise you will be redirected to the login page.
+      </p>
+      <p>The check is done via a fetch call on the client using SWR.</p>
+      <p>
+        One benefit of using{" "}
+        <a href="https://swr.vercel.app" target="_blank">
+          SWR
+        </a>
+        : if you open the page in different tabs/windows, and logout from one
+        place, every other tab/window will be synced and logged out.
+      </p>
+    </div>
+  );
+}

--- a/nextjs/nextjs-site/app/protected-pages/protected-middleware/page.jsx
+++ b/nextjs/nextjs-site/app/protected-pages/protected-middleware/page.jsx
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { getIronSession } from "iron-session";
+import { SessionData, sessionOptions } from "../lib";
+import Link from "next/link";
+
+async function getSession() {
+  const session = await getIronSession(cookies(), sessionOptions);
+  return session;
+}
+
+export default function ProtectedServer() {
+  return (
+    <main className="p-10 space-y-5">
+      <h1>This is a protected page via middleware</h1>
+      <Content />
+      <p>
+        <Link
+          href="/protected-pages"
+        >
+          ← Back
+        </Link>
+      </p>
+    </main>
+  );
+}
+
+async function Content() {
+  const session = await getSession();
+
+  return (
+    <div className="max-w-xl space-y-2">
+      <p>
+        Hello <strong>{session.username}!</strong>
+      </p>
+      <p>
+        This page is protected and can only be accessed if you are logged in.
+        Otherwise you will be redirected to the login page.
+      </p>
+      <p>The check is done via a middleware.</p>
+    </div>
+  );
+}

--- a/nextjs/nextjs-site/app/protected-pages/protected-server/page.jsx
+++ b/nextjs/nextjs-site/app/protected-pages/protected-server/page.jsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { getIronSession } from "iron-session";
+import { SessionData, sessionOptions } from "../lib";
+import Link from "next/link";
+
+async function getSession() {
+  const session = await getIronSession(cookies(), sessionOptions);
+
+  return session;
+}
+
+export default function ProtectedServer() {
+  return (
+    <main className="p-10 space-y-5">
+      <h1>Protected server page</h1>
+      <Suspense fallback={<p className="text-lg">Loading...</p>}>
+        <Content />
+      </Suspense>
+      <p>
+        <Link
+          href="/protected-pages"
+        >
+          ← Back
+        </Link>
+      </p>
+    </main>
+  );
+}
+
+async function Content() {
+  const session = await getSession();
+
+  if (!session.isLoggedIn) {
+    redirect("/protected-pages");
+  }
+
+  return (
+    <div className="max-w-xl space-y-2">
+      <p>
+        Hello <strong>{session.username}!</strong>
+      </p>
+      <p>
+        This page is protected and can only be accessed if you are logged in.
+        Otherwise you will be redirected to the login page.
+      </p>
+      <p>The check is done via a server component.</p>
+    </div>
+  );
+}

--- a/nextjs/nextjs-site/app/protected-pages/session/route.js
+++ b/nextjs/nextjs-site/app/protected-pages/session/route.js
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { getIronSession } from "iron-session";
+import { defaultSession, sessionOptions } from "../lib";
+import { sleep, SessionData } from "../lib";
+
+// login
+export async function POST(request) {
+  const session = await getIronSession(cookies(), sessionOptions);
+
+  const { username = "No username" } = (await request.json());
+
+  session.isLoggedIn = true;
+  session.username = username;
+  await session.save();
+
+  // simulate looking up the user in db
+  await sleep(250);
+
+  return Response.json(session);
+}
+
+// read session
+export async function GET() {
+  const session = await getIronSession(cookies(), sessionOptions);
+
+  // simulate looking up the user in db
+  await sleep(250);
+
+  if (session.isLoggedIn !== true) {
+    return Response.json(defaultSession);
+  }
+
+  return Response.json(session);
+}
+
+// logout
+export async function DELETE() {
+  const session = await getIronSession(cookies(), sessionOptions);
+
+  session.destroy();
+
+  return Response.json(defaultSession);
+}

--- a/nextjs/nextjs-site/app/protected-pages/use-session.js
+++ b/nextjs/nextjs-site/app/protected-pages/use-session.js
@@ -1,0 +1,47 @@
+import useSWR from "swr";
+import { SessionData, defaultSession } from "./lib";
+import useSWRMutation from "swr/mutation";
+
+const sessionApiRoute =
+  "/protected-pages/session";
+
+async function fetchJson(input, init) {
+  return fetch(input, {
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json"
+    },
+    ...init
+  }).then(res => res.json())
+}
+
+function doLogin(url, { arg }) {
+  return fetchJson(url, {
+    method: "POST",
+    body: JSON.stringify({ username: arg })
+  })
+}
+
+function doLogout(url) {
+  return fetchJson(url, {
+    method: "DELETE"
+  })
+}
+
+export default function useSession() {
+  const { data: session, isLoading } = useSWR(
+    sessionApiRoute,
+    fetchJson,
+    {
+      fallbackData: defaultSession,
+    },
+  );
+
+  const { trigger: login } = useSWRMutation(sessionApiRoute, doLogin, {
+    // the login route already provides the updated information, no need to revalidate
+    revalidate: false,
+  });
+  const { trigger: logout } = useSWRMutation(sessionApiRoute, doLogout);
+
+  return { session, logout, login, isLoading };
+}

--- a/nextjs/nextjs-site/package-lock.json
+++ b/nextjs/nextjs-site/package-lock.json
@@ -5,9 +5,11 @@
   "packages": {
     "": {
       "dependencies": {
+        "iron-session": "^8.0.1",
         "next": "latest",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "swr": "^2.2.5"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -2750,6 +2752,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -4543,6 +4553,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iron-session": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-8.0.1.tgz",
+      "integrity": "sha512-ZQKazQRn/J5YaXY+CQ69V9lx9boh4swl+BgnNC1knxyZgBjhiXuGpY60URRntMPib9QdrsN9qAOTqdMFMbGYXg==",
+      "funding": [
+        "https://github.com/sponsors/vvo",
+        "https://github.com/sponsors/brc-dd"
+      ],
+      "dependencies": {
+        "cookie": "0.6.0",
+        "iron-webcrypto": "1.0.0",
+        "uncrypto": "0.1.3"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.0.0.tgz",
+      "integrity": "sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arguments": {
@@ -7400,6 +7432,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7674,6 +7718,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -7736,6 +7785,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/nextjs/nextjs-site/package.json
+++ b/nextjs/nextjs-site/package.json
@@ -8,9 +8,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "iron-session": "^8.0.1",
     "next": "latest",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "swr": "^2.2.5"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to a portion of #22 

- adapted the [typescript heavy example app](https://github.com/vvo/iron-session/tree/main/examples/next/src/app/app-router-client-component-route-handler-swr) from the iron-session repo. They have multiple, I picked this one because it was "recommended" by them and uses the app router.
- currently just a draft PR so we can study it and figure out what we like or don't like

## Things to check

- Do the session checks make sense via different methods? Client component vs middleware vs server component?
- Does it make sense how sessions are saved / updated / destroyed?

Also, I'm proactively sorry about the linting errors I'm sure are about to pop up, I can fix them all if we decide we kinda like this code.

## Security considerations

None at the moment as this is just a demo app. However, we should consider what this might look like if implemented in our prototype and what additional security considerations we might have.
