### PR TITLE
adds directories and files to cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,2 +1,15 @@
+docs/
+.github/
+
+# configuration files
 .env.local
+.env.cloud.example.yml
+
+# generated files
 node_modules/
+.next/
+
+# local development tools
+cgui-db-docker/
+uaa-docker/
+__tests__/


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds directories and files to `.cfignore` file to prevent them being pushed unnecessarily to cloud on `cf push`

## Things to check

- Are there any other files that should be excluded?

## Security considerations

None other than making sure we're not pushing variables or something that should not be available in cloud
