### PR TITLE
adds explainers directory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 
 - For any logging statements, is there any chance that they could be logging sensitive data?
 - Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
+- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?
 
 ## Security considerations
 

--- a/docs/explainers/README.md
+++ b/docs/explainers/README.md
@@ -1,0 +1,9 @@
+# About explainers
+
+An explainer is a short description of a process or concept which was initially unclear to our team. Explainers are intended to help new members understand concepts, as well as to jog the memories of existing members.
+
+Explainers do not document decisions; use ADRs for this purpose. Explainers are intended to be higher level than the documentation you might find on a pull request explaining the mechanics of a feature.
+
+## Creating a new explainer
+
+For new explainers, please use [template.md](template.md). The entire length of an explainer should be less than 500 words (roughly a single page).

--- a/docs/explainers/template.md
+++ b/docs/explainers/template.md
@@ -1,0 +1,16 @@
+# Short but descriptive title
+
+## What is *[topic]* ?
+
+Give a brief, plain language summary of the concept you are explaining.
+
+### Context
+
+Describe how this process or concept is related to our project. Why do we need to know about it? When are we likely to encounter it?
+
+## Further reading
+
+Add links to documentation or repositories with implementations that might be valuable for someone seeking further information.
+
+* *[link]*
+* *[link]*


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds explainers directory with description of what an explainer is and a template
- inserts reminder to update documentation into the PR template

Closes #103 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, non-sensitive documentation
