### PR TITLE
Exclude dependabot branches from security considerations workflow

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -3,6 +3,8 @@ name: Security Considerations Workflow
 on:
   pull_request:
     types: [opened, edited, reopened]
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   security-considerations:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Excludes dependabot branches from security considerations github actions workflow

This workflow checks the PR content to ensure there is a specific section on security considerations as defined by cloud-gov.

Since we cannot control the content of dependabot PR's, this workflow always fails for dependabot PR's, which gives a faulty impression that the PR is failing for other more substantial reasons.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?

## Security considerations

- Allows dependabot branches to bypass this check
