### PR TITLE
Fix: switch approach to excluding dependabot pr's from running security considerations job

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -3,11 +3,10 @@ name: Security Considerations Workflow
 on:
   pull_request:
     types: [opened, edited, reopened]
-    branches-ignore:
-      - 'dependabot/**'
 
 jobs:
   security-considerations:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: cloud-gov/security-considerations-action@main


### PR DESCRIPTION
The old way was ineffective

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?

## Security considerations

Similar considerations to #120 
