### PR TITLE
Add vscode configs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 .env.cloud.yml
+
+# vscode stuff
+.vscode/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add vscode configs folder to gitignore. This folder is autogenerated by VSCode.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?

## Security considerations

- prevents personal environment configs from being checked into the codebase
