### PR TITLE
adds script and instructions to refresh token without manual copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ To obtain your token, first log into the correct environment in your CLI:
 cf login -a [your cf domain] --sso
 ```
 
-Then run:
+You can view your token at `cf oauth-token` and manually copy everything after "bearer" into `CF_API_TOKEN`, or you can run a script to do this for you:
 
 ```
-cf oauth-token
+./token-refresh.sh
 ```
 
-Copy this token and set it as your `CF_API_TOKEN` in `env.local`. Do not copy "bearer" at the beginning of the token.
+This command will be run automatically when you start your application if you use `npm run dev-cf`.
 
 Note that oauth tokens expire frequently. To obtain a new token, just run `cf oauth-token` again and replace your previous variable value with the new one.
 
@@ -81,6 +81,10 @@ docker-compose up
 Then run the dev server:
 
 ```bash
+# to run with a valid cloud foundry token
+npm run dev-cf
+
+# to run without accessing cloud foundry resources
 npm run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
+    "dev-cf": "./token-refresh.sh; next dev",
     "start": "next start",
     "test": "jest",
     "lint": "next lint",

--- a/token-refresh.sh
+++ b/token-refresh.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+# Quick script that obtains the token from cloud foundry
+# and adds it to the user's local environment variables
+#
+# Note: you must be logged into the cloud foundry CLI
+# for this script to work
+
+file=".env.local"
+
+cf_res=$(cf oauth-token)
+token=${cf_res#* }
+
+if [ "$token" == "FAILED" ]; then
+  exit 1
+else
+  sed -i '' -e "s/CF_API_TOKEN=.*/CF_API_TOKEN=${token}/" $file
+  echo "Added token to ${file}"
+fi


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds simple bash script to smash the CF command line access token into our `env.local` files

I am not a sophisticated bash script writer, so please flag if there are more idiomatic ways of doing any of this!

Things I tested:
- when logged out, CF provides you instructions to log in and the script exits
- when CF_API_TOKEN is followed by other variables, they are not overwritten / disturbed by changes
- when CF_API_TOKEN is already set, the value will be overwritten

Closes #155 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?

## Security considerations

We're appropriating the token for a use case it wasn't intended for, but we were already doing that, this just makes it more convenient.
