### PR TITLE
updates PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,14 @@
 -
 -
 
-## Things to check
+### Related issues
 
-- For any logging statements, is there any chance that they could be logging sensitive data?
-- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
-- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?
+
+
+### Submitter checklist
+
+- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
+- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)
 
 ## Security considerations
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- changes the PR template to use a checklist for prompting us to doublecheck code

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.
- Have you updated or added relevant documentation (README, ADRs, explainers, etc)?

## Security considerations

None other than having shortened the description of logging levels and ramifications
