### PR TITLE
provides error message if no local token nor uaa token found

### DIFF
--- a/__tests__/api/cloudfoundry/token.test.js
+++ b/__tests__/api/cloudfoundry/token.test.js
@@ -37,13 +37,21 @@ describe('cloudfoundry token tests', () => {
       describe('when auth cookie is not set', () => {
         beforeEach(() => {
           cookies.mockImplementation(() => ({
-            get: () => null,
+            get: () => undefined,
           }));
         });
         it('throws an error when no cookie is set', () => {
-          expect(() => getToken()).toThrow(
-            'accessToken not found, please confirm you are logged in'
-          );
+          expect(() => getToken()).toThrow('please confirm you are logged in');
+        });
+      });
+      describe('when auth cookie is not in an expected format', () => {
+        beforeEach(() => {
+          cookies.mockImplementation(() => ({
+            get: () => 'unexpected format',
+          }));
+        });
+        it('throws an error', () => {
+          expect(() => getToken()).toThrow('unable to parse accessToken');
         });
       });
     });

--- a/api/cloudfoundry/token.ts
+++ b/api/cloudfoundry/token.ts
@@ -8,11 +8,12 @@ export function getToken(): string {
 
 function getCFToken(): string {
   const authSession = cookies().get('authsession');
-  if (authSession === undefined) throw new Error();
+  if (authSession === undefined)
+    throw new Error('please confirm you are logged in');
   try {
     return JSON.parse(authSession.value).accessToken;
   } catch (error: any) {
-    throw new Error('accessToken not found, please confirm you are logged in');
+    throw new Error('unable to parse accessToken');
   }
 }
 


### PR DESCRIPTION
Previously if neither a local token (`CF_API_TOKEN`) nor a UAA token were found, pages requiring the token would appear blank and no errors would be printed to terminal nor console. This made realizing that your local env variable was missing difficult to debug.

## Changes proposed in this pull request:

- adds an error message when the cookie version of a token is not saved indicating you are not logged in

This is a pretty minor change but I think that printing a more intelligible error will help us debug when something has happened to our local token's setup.


### Related issues

closes #157 

#157 also mentioned the `CF_API_URL` variable, but testing with this indicates it is not the cause of the blank white page, and devs will be presented with the error: `Failed to parse URL from undefined/[path]`

### Submitter checklist

- [x] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [x] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, except for revealing a little information to the user about the inner workings of the application if there is an error
