### PR TITLE
Handle logout redirect

### DIFF
--- a/.env.example.local
+++ b/.env.example.local
@@ -7,6 +7,7 @@ DATABASE_URL=postgresql://postgres:password@localhost:5434/cgui
 # UAA
 #   Connect to your local UAA instance
 #
+AUTH_CALLBACK_PATH=auth/login/callback
 OAUTH_CLIENT_ID=my_client_id
 OAUTH_CLIENT_SECRET=my_client_secret
 UAA_ROOT_URL=http://localhost:9001

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5434/cgui-test
+AUTH_CALLBACK_PATH=auth/login/callback
 OAUTH_CLIENT_ID=my_client_id
 OAUTH_CLIENT_SECRET=my_client_secret
 ROOT_URL=http://localhost:3000/


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use pre-approved `redirect_uri`  in UAA client for post-logout callback
  - (Alternatively, we could add an additional `redirect_uri` if we'd like to use a distinct uri)
- `auth/login/callback` will redirect to `/` based on the lack of a session cookie

### Related issues
https://github.com/cloud-gov/cg-ui/issues/163

### Submitter checklist

- [x] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [x] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None