### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-issue.md
+++ b/.github/ISSUE_TEMPLATE/default-issue.md
@@ -1,0 +1,19 @@
+---
+name: Default issue
+about: 'If you''re unsure which template to use, start here. '
+title: ''
+labels: squad-dashboard
+assignees: ''
+
+---
+
+_Can this task be done in one increment?_
+_If not, please break it up into smaller issues._ 
+_If this is unknown, label the issue as "research"._ 
+
+
+_Ensure this issue has a clear Definition of Done in the Acceptance Criteria list below:_ 
+### Acceptance Criteria
+- [ ] .
+- [ ] .
+- [ ] .


### PR DESCRIPTION
TIL that Github now has a GUI for creating more robust issue templates and assigning default labels. 

Since we're not using our existing issue templates anyway, let's use this one, which is more in line with how we've been creating issues. 

### Security Considerations
None