### PR TITLE
Fetch real org name in an org-specific layout

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,4 @@
 import { Banner } from '@/components/uswds/Banner';
-import { Header } from '@/components/Header';
 import { Identifier } from '@/components/uswds/Identifier';
 import { Footer } from '@/components/uswds/Footer';
 import { Sidebar } from '@/components/Sidebar';
@@ -23,8 +22,7 @@ export default function RootLayout({ children }) {
             <Sidebar />
           </div>
           <div className="desktop:grid-col-10 bg-white height-full flex-column display-flex">
-            <Header />
-            <main className="padding-4 overflow-y-auto">{children}</main>
+            {children}
           </div>
         </div>
         <Footer />

--- a/app/orgs/[orgId]/layout.tsx
+++ b/app/orgs/[orgId]/layout.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { LayoutHeader } from '@/components/LayoutHeader';
+import { getOrg } from '@/controllers/controllers';
+
+export default async function OrgLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { orgId: string };
+}) {
+  const { payload } = await getOrg(params.orgId);
+  const orgName = payload.name;
+
+  return (
+    <>
+      <LayoutHeader>{orgName}</LayoutHeader>
+      <main className="padding-4 overflow-y-auto">{children}</main>
+    </>
+  );
+}

--- a/components/LayoutHeader.tsx
+++ b/components/LayoutHeader.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import { cookies } from 'next/headers';
 import { LoginButton } from './auth/LoginButton';
 import { LogoutButton } from './auth/LogoutButton';
 
-export function Header() {
+export function LayoutHeader({ children }: { children: React.ReactNode }) {
   const cookieStore = cookies();
   const authSession = cookieStore.get('authsession');
 
@@ -12,7 +13,7 @@ export function Header() {
         {authSession ? <LogoutButton /> : <LoginButton />}
       </div>
       <div className="padding-x-4 font-ui-lg padding-y-2 text-semibold">
-        Org : 18F Stratos rebuild
+        {children}
       </div>
     </div>
   );


### PR DESCRIPTION
## Changes proposed in this pull request:

- fetches real org name in org-specific layout
- create a `LayoutHeader` React component for reuse in other route-specific layouts

### Related issues

Closes #240 
(implements Option 2 from issue discussion)

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

fetches cloudfoundry org, but otherwise UI-related
