### PR TITLE
Add aria labels for certain users list items

### DIFF
--- a/components/UsersList/UsersListLastLogin.tsx
+++ b/components/UsersList/UsersListLastLogin.tsx
@@ -2,7 +2,9 @@
 
 import { isDateExpired, daysToExpiration } from '@/helpers/dates';
 
-export function formatDate(timestamp: number): string {
+export function formatDate(timestamp: number | null): string {
+  if (!timestamp) return '';
+
   return new Date(timestamp).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
@@ -10,7 +12,9 @@ export function formatDate(timestamp: number): string {
   });
 }
 
-export function formatTime(timestamp: number): string {
+export function formatTime(timestamp: number | null): string {
+  if (!timestamp) return '';
+
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   return new Date(timestamp).toLocaleTimeString('en-US', {
     timeZone: tz,
@@ -32,22 +36,23 @@ export function UsersListLastLogin({
   const expiresInDays: number = timestamp
     ? daysToExpiration(timestamp, expirationWindowDays)
     : 0;
+  const showTimestamp: boolean = !!timestamp && !isExpired;
   return (
-    <div className="text-right text-base">
+    <div className="text-right text-base" aria-label="last login time">
       <div>
         {!timestamp && 'Never logged in'}
         {timestamp && isExpired && 'Login expired'}
-        {timestamp && !isExpired && formatTime(timestamp)}
+        {showTimestamp && formatTime(timestamp)}
       </div>
-      <div>
+      <div aria-label="last login date">
         {(!timestamp || (timestamp && isExpired)) && (
           <button className="usa-button usa-button--unstyled">
             Resend invite
           </button>
         )}
-        {timestamp && !isExpired && formatDate(timestamp)}
+        {showTimestamp && formatDate(timestamp)}
       </div>
-      {timestamp && !isExpired && (
+      {showTimestamp && (
         <div className="padding-top-1 text-italic">
           Login expires in {expiresInDays} day{expiresInDays > 1 && 's'}
         </div>

--- a/components/UsersList/UsersListOrgRoles.tsx
+++ b/components/UsersList/UsersListOrgRoles.tsx
@@ -55,6 +55,7 @@ export function UsersListOrgRoles({
           <Link
             href="/todo"
             className="usa-button usa-button--unstyled font-body-2xs"
+            aria-label="Edit organization roles for this user"
           >
             Edit
           </Link>

--- a/components/UsersList/UsersListSpaceRoles.tsx
+++ b/components/UsersList/UsersListSpaceRoles.tsx
@@ -33,6 +33,7 @@ export function UsersListSpaceRoles({
           <Link
             href="/todo"
             className="usa-button usa-button--unstyled margin-right-2 font-body-2xs"
+            aria-label="edit spaces and roles for this user"
           >
             Edit
           </Link>
@@ -42,6 +43,7 @@ export function UsersListSpaceRoles({
             <Link
               href="/todo"
               className="usa-button usa-button--unstyled font-body-2xs"
+              aria-label="view all spaces and roles for this user"
             >
               View All
             </Link>


### PR DESCRIPTION
## Changes proposed in this pull request:

- added aria labels for last login time and date
- also added some more descriptive labels for edit and view all buttons

### How to test:
- Open a users list page: `/org/[orgId]`
- Open Voiceover for Mac (Command + F5)
- Have VO read through the text of the users list (Control + Option + A)

### Related issues

Closes #273 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, a11y UI changes only
