### PR TITLE
inserts fake data if UAA API not accessible by user

### DIFF
--- a/__tests__/helpers/dates.test.js
+++ b/__tests__/helpers/dates.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { isDateExpired, daysToExpiration } from '@/helpers/dates';
+import {
+  addDays,
+  daysToExpiration,
+  isDateExpired,
+  randomDate,
+} from '@/helpers/dates';
 
 describe('isDateExpired', () => {
   it("returns true when today's date is past expiration", () => {
@@ -22,5 +27,23 @@ describe('daysToExpiration', () => {
     const timestamp = new Date(now.setDate(now.getDate() - 2)).toISOString(); // 2 days ago
     const result = daysToExpiration(timestamp, 90); // 90 day expiration window
     expect(result).toEqual(88);
+  });
+});
+
+describe('randomDate', () => {
+  it('returns a day between now and a week from now', () => {
+    const now = new Date();
+    const future = addDays(new Date(), 7);
+    const result = randomDate(now, future).getTime();
+    expect(result).toBeGreaterThanOrEqual(now.getTime());
+    expect(result).toBeLessThanOrEqual(future.getTime());
+  });
+
+  it('returns a day in the past', () => {
+    const distantPast = addDays(new Date(), -365);
+    const recentPast = addDays(new Date(), -30);
+    const result = randomDate(distantPast, recentPast).getTime();
+    expect(result).toBeGreaterThanOrEqual(distantPast.getTime());
+    expect(result).toBeLessThanOrEqual(recentPast.getTime());
   });
 });

--- a/controllers/controller-helpers.ts
+++ b/controllers/controller-helpers.ts
@@ -1,6 +1,16 @@
-import { RolesByUser, UserWithRoles, RoleRanking } from './controller-types';
-import { ListRolesRes, RoleObj } from '@/api/cf/cloudfoundry-types';
-import { RoleType } from '@/api/cf/cloudfoundry-types';
+import {
+  RolesByUser,
+  UserWithRoles,
+  RoleRanking,
+  UAAUser,
+} from './controller-types';
+import {
+  ListRolesRes,
+  RoleObj,
+  RoleType,
+  UserObj,
+} from '@/api/cf/cloudfoundry-types';
+import { addDays, randomDate } from '@/helpers/dates';
 
 export function resourceKeyedById(resource: Array<any>): Object {
   return resource.reduce((acc, item) => {
@@ -93,4 +103,48 @@ export function associateUsersWithRolesTest(
       return a.username ? a.username.localeCompare(b.username) : 1;
     });
   return users;
+}
+
+export function createFakeUaaUser(user: UserObj): UAAUser {
+  const cases = [
+    // never logged in
+    {
+      id: user.guid,
+      verified: false,
+      active: false,
+      previousLogonTime: null,
+    },
+    // logged in previously but expired
+    {
+      id: user.guid,
+      verified: true,
+      active: false,
+      previousLogonTime: randomDate(
+        addDays(new Date(), -180),
+        addDays(new Date(), -90)
+      ).getTime(),
+    },
+    // logged in recently
+    {
+      id: user.guid,
+      verified: true,
+      active: true,
+      previousLogonTime: randomDate(
+        addDays(new Date(), -10),
+        addDays(new Date(), -1)
+      ).getTime(),
+    },
+    // logged in previously, not expired
+    {
+      id: user.guid,
+      verified: true,
+      active: true,
+      previousLogonTime: randomDate(
+        addDays(new Date(), -89),
+        addDays(new Date(), -11)
+      ).getTime(),
+    },
+  ];
+  const index = Math.floor(Math.random() * cases.length);
+  return cases[index];
 }

--- a/controllers/controller-types.ts
+++ b/controllers/controller-types.ts
@@ -1,7 +1,7 @@
 import { RoleType, SpaceObj } from '@/api/cf/cloudfoundry-types';
 
 export interface UAAUser {
-  previousLogonTime: number;
+  previousLogonTime: number | null;
   verified: boolean;
   active: boolean;
   id: string;

--- a/controllers/controllers.ts
+++ b/controllers/controllers.ts
@@ -9,13 +9,14 @@ import {
   AddOrgRoleArgs,
   AddSpaceRoleArgs,
   ControllerResult,
-  UserMessage,
   Result,
+  UserMessage,
   UAAUsersById,
 } from './controller-types';
 import {
   associateUsersWithRoles,
   associateUsersWithRolesTest,
+  createFakeUaaUser,
   resourceKeyedById,
 } from './controller-helpers';
 
@@ -336,24 +337,37 @@ export async function getOrgPage(orgGuid: string): Promise<ControllerResult> {
     ),
   ]);
 
-  [spaceRolesRes, userInfoRes].map((res) => {
-    if (!res.ok) {
-      if (process.env.NODE_ENV == 'development') {
-        console.error(
-          `api error on cf org page with http code ${res.status} for url: ${res.url}`
-        );
-      }
-      throw new Error('something went wrong with the request');
+  if (!spaceRolesRes.ok) {
+    if (process.env.NODE_ENV == 'development') {
+      console.error(
+        `api error on cf org page with http code ${spaceRolesRes.status} for url: ${spaceRolesRes.url}`
+      );
     }
-  });
+    throw new Error('something went wrong with the request');
+  }
+  if (!userInfoRes.ok && userInfoRes.status != 403) {
+    if (process.env.NODE_ENV == 'development') {
+      console.error(
+        `uaa api error on cf org page with http code ${spaceRolesRes.status} for url: ${spaceRolesRes.url}`
+      );
+    }
+    throw new Error('something went wrong with the request');
+  }
+  const uaaUsers =
+    userInfoRes.status == 403
+      ? resourceKeyedById(
+          users.map(function (user: UserObj) {
+            return createFakeUaaUser(user);
+          })
+        )
+      : (resourceKeyedById(
+          (await userInfoRes.json()).resources
+        ) as UAAUsersById);
 
   const spaceRoles = (await spaceRolesRes.json()).resources;
   const rolesByUser = associateUsersWithRoles(
     orgUserRolesPayload.resources.concat(spaceRoles)
   );
-
-  const userInfo = await userInfoRes.json();
-  const uaaUsers = resourceKeyedById(userInfo.resources) as UAAUsersById;
 
   return {
     meta: { status: 'success' },

--- a/helpers/dates.tsx
+++ b/helpers/dates.tsx
@@ -24,3 +24,10 @@ export function daysToExpiration(
   const now = new Date();
   return Math.round((futureDate - now.getTime()) / 1000 / 60 / 60 / 24);
 }
+
+// taken from https://stackoverflow.com/a/60180035
+export function randomDate(from: Date, to: Date) {
+  const fromTime = from.getTime();
+  const toTime = to.getTime();
+  return new Date(fromTime + Math.random() * (toTime - fromTime));
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- if a user does not have access to the UAA API (403 response), inserts fake data for log in information
- creates randomDate function to help with the fake information
- four cases: never logged in, logged in but expired, logged in not expired, and logged in very recently not expired. This helps "weight" non-expired users.

### Related issues

closes #270 
address part of #258, in that we can now test a non 200 UAA result, but we still need to test 500 / other errors

### Submitter checklist

- [X] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

Fake data only
