### PR TITLE
fix: fallback to error message when getOrg request fails

### DIFF
--- a/app/orgs/[orgId]/layout.tsx
+++ b/app/orgs/[orgId]/layout.tsx
@@ -9,12 +9,13 @@ export default async function OrgLayout({
   children: React.ReactNode;
   params: { orgId: string };
 }) {
-  const { payload } = await getOrg(params.orgId);
-  const orgName = payload.name;
+  const { payload, success } = await getOrg(params.orgId);
 
   return (
     <>
-      <LayoutHeader>{orgName}</LayoutHeader>
+      <LayoutHeader>
+        {success ? payload.name : 'Org name not found'}
+      </LayoutHeader>
       <main className="padding-4 overflow-y-auto">{children}</main>
     </>
   );

--- a/controllers/controllers.ts
+++ b/controllers/controllers.ts
@@ -223,6 +223,13 @@ export async function getOrg(guid: string): Promise<Result> {
   };
   try {
     const res = await CF.getOrg(guid);
+    if (!res.ok) {
+      return {
+        success: false,
+        status: 'error',
+        message: 'something went wrong with the request',
+      };
+    }
     return await mapCfResult(res, message);
   } catch (error: any) {
     if (process.env.NODE_ENV == 'development') {


### PR DESCRIPTION
## Changes proposed in this pull request:

Show an error message when org id fails

A unit test for this layout will be warranted, but this is a quick fix for now. 

### Related issues

Fixes #240 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI changes only
