### PR TITLE
don't break the spaces in the extra spaces link

### DIFF
--- a/__tests__/components/UsersList/UsersListSpaceRoles.test.js
+++ b/__tests__/components/UsersList/UsersListSpaceRoles.test.js
@@ -34,7 +34,7 @@ describe('UsersListSpaceRoles', () => {
       render(<UsersListSpaceRoles spaces={mockSpaces} roles={mockRoles} />);
       // query
       const extraSpace = screen.queryByText('fooRoleRame5');
-      const overflowNum = screen.queryByText('+ 1');
+      const overflowNum = screen.queryByText('+1');
       // assert
       expect(extraSpace).not.toBeInTheDocument();
       expect(overflowNum).toBeInTheDocument();

--- a/app/page.js
+++ b/app/page.js
@@ -11,15 +11,18 @@ export default function Home() {
       <h1>Welcome to the cloud.gov dashboard prototype</h1>
 
       <div
-        class="usa-summary-box"
+        className="usa-summary-box"
         role="region"
         aria-labelledby="summary-box-key-information"
       >
-        <div class="usa-summary-box__body">
-          <h4 class="usa-summary-box__heading" id="summary-box-key-information">
+        <div className="usa-summary-box__body">
+          <h4
+            className="usa-summary-box__heading"
+            id="summary-box-key-information"
+          >
             Usability testing
           </h4>
-          <div class="usa-summary-box__text">
+          <div className="usa-summary-box__text">
             {authSession ? <LogoutButton /> : <LoginButton />}
             <p>
               <Link href="/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd">

--- a/components/UsersList/UsersListSpaceRoles.tsx
+++ b/components/UsersList/UsersListSpaceRoles.tsx
@@ -71,8 +71,11 @@ export function UsersListSpaceRoles({
           </div>
         ))}
         {extra > 0 && (
-          <Link href="/todo" className="usa-button usa-button--unstyled">
-            + {extra}
+          <Link
+            href="/todo"
+            className="usa-button usa-button--unstyled text-no-wrap"
+          >
+            +{extra}
           </Link>
         )}
       </div>


### PR DESCRIPTION
Also fixes className vs class on homepage

## Changes proposed in this pull request:

- Fixes space breaks in the extra space roles link in users list
- Also fixes `className` vs `class` for React/JSX css classes on homepage

Updated screenshot:

![Screenshot 2024-06-14 at 9 45 37 AM](https://github.com/cloud-gov/cg-ui/assets/4267629/89fffa7b-b473-4639-94e3-b3724c6b8e87)


### Related issues

fix for #237

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI change only
