### PR TITLE
Add UI for org roles form

### DIFF
--- a/__tests__/components/UsersActions/UsersActionsOrgRoles.test.js
+++ b/__tests__/components/UsersActions/UsersActionsOrgRoles.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UsersActionsOrgRoles } from '@/components/UsersActions/UsersActionsOrgRoles';
+
+describe('UsersActionsOrgRoles', () => {
+  // render
+  render(<UsersActionsOrgRoles />);
+  // query
+  const checkBox = screen.getByRole('checkbox', { name: /Billing manager/ });
+  const label = screen.getByTestId('label_billing_manager');
+
+  it('checks a checkbox on click', () => {
+    // expect
+    expect(checkBox.checked).toEqual(false);
+    // act
+    fireEvent.click(checkBox);
+    // expect
+    expect(checkBox.checked).toEqual(true);
+  });
+
+  it('unchecks a checkbox on subsequent click', () => {
+    // act
+    fireEvent.click(checkBox);
+    // expect
+    expect(checkBox.checked).toEqual(false);
+  });
+
+  it('handles check events when a label is clicked', () => {
+    // act
+    fireEvent.click(label);
+    // expect
+    expect(checkBox.checked).toEqual(true);
+  });
+});

--- a/app/orgs/[orgId]/users/[userId]/org-roles/page.tsx
+++ b/app/orgs/[orgId]/users/[userId]/org-roles/page.tsx
@@ -1,0 +1,20 @@
+import { PageHeader } from '@/components/PageHeader';
+import { UsersActionsOrgRoles } from '@/components/UsersActions/UsersActionsOrgRoles';
+
+export default function OrgUserOrgRolesPage() {
+  const username = 'bento.bear@gsa.gov'; // TODO: replace with real username
+
+  return (
+    <div className="maxw-mobile-lg">
+      <div className="usa-prose">
+        <PageHeader heading={username} />
+        <h4>Org roles</h4>
+        <p>
+          Optional. By assigning additional roles, you can grant access to org
+          level information and features.
+        </p>
+        <UsersActionsOrgRoles />
+      </div>
+    </div>
+  );
+}

--- a/components/UsersActions/UsersActionsOrgRoles.tsx
+++ b/components/UsersActions/UsersActionsOrgRoles.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/uswds/Button';
+
+type FormRoles = {
+  [role_type: string]: {
+    name: string;
+    type: string;
+    description: string;
+    selected: boolean;
+    default: boolean;
+  };
+};
+
+const initialRoles = {
+  organization_user: {
+    name: 'User',
+    type: 'organization_user',
+    description:
+      'Does not have org level access. Can be added to spaces by org managers',
+    selected: false,
+    default: true,
+  },
+  billing_manager: {
+    name: 'Billing manager',
+    type: 'billing_manager',
+    description:
+      'Create and manage the billing account and payment info for org',
+    selected: false,
+    default: false,
+  },
+  organization_auditor: {
+    name: 'Org auditor',
+    type: 'organization_auditor',
+    description:
+      'View logs, reports, and settings for org and ALL of the orgs spaces',
+    selected: false,
+    default: false,
+  },
+  organization_manager: {
+    name: 'Org manager',
+    type: 'organization_manager',
+    description: 'Can also manage users and enable features',
+    selected: false,
+    default: false,
+  },
+};
+
+export function UsersActionsOrgRoles() {
+  const [roles, setRoles] = useState(initialRoles as FormRoles);
+
+  function setCheckboxState(value: string) {
+    var newRoles = { ...roles };
+    var newValue = !newRoles[value].selected;
+    newRoles[value].selected = newValue;
+    setRoles(newRoles);
+  }
+
+  function handleChange(event: any) {
+    const value = event.target.id;
+    setCheckboxState(value);
+  }
+  /* Since USWDS labels are clickable (and hide the actual checkboxes),
+  we need to handle click events on the label as if they were check/uncheck actions. */
+  function handleLabelClick(event: any) {
+    event.preventDefault();
+    const value = event.target.getAttribute('for');
+    setCheckboxState(value);
+  }
+
+  return (
+    <form>
+      <fieldset className="usa-fieldset">
+        <legend className="usa-legend">
+          <strong>Select org roles</strong>
+        </legend>
+        <div className="margin-3">
+          {Object.values(roles).map((role, i) => (
+            <div
+              key={`UsersActionsOrgRoles-checkbox-${i}`}
+              className={`usa-checkbox margin-bottom-3 ${role.default ? 'default' : ''}`}
+            >
+              <input
+                className="usa-checkbox__input"
+                id={role.type}
+                type="checkbox"
+                name={role.type}
+                checked={role.selected || role.default}
+                disabled={!!role.default}
+                onChange={handleChange}
+              />
+              <label
+                className="usa-checkbox__label"
+                htmlFor={role.type}
+                onClick={handleLabelClick}
+                data-testid={`label_${role.type}`}
+              >
+                <strong>{role.name}</strong>
+                <span className="usa-checkbox__label-description">
+                  {role.description}
+                </span>
+              </label>
+            </div>
+          ))}
+        </div>
+        <div className="padding-top-3 border-top-1px">
+          <Button unstyled>Cancel</Button>
+          <Button className="margin-left-4">Save</Button>
+        </div>
+      </fieldset>
+    </form>
+  );
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds UI for edit org roles form (UI only; form is not functional, but checkboxes can be checked/unchecked)

### Notes

- Did not spend too much time on getting the CSS exactly right because we're using outdated designs that will likely change. Form uses OOTB USWDS components and utilities.
- User role is checked and disabled by default
- You can see it in action on `http://localhost:3000/orgs/foo/users/bar/org-roles`

### Related issues

Part of #210 

### Screenshot

![Screenshot 2024-06-26 at 3 57 35 PM](https://github.com/cloud-gov/cg-ui/assets/4267629/fc57dcdd-d698-448a-b42e-6c4e0b30ecf2)

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI only
