### PR TITLE
binds s3 bucket via manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,7 @@ applications:
     timeout: 180
     services:
       - cg-ui-datastore
+      - cg-ui-storage
     env:
       AUTH_CALLBACK_PATH: auth/login/callback
       CF_API_URL: ((CF_API_URL))


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds the s3 service name from the CI pipeline to our manifest file to ensure that when being deployed from scratch, we do not need to manually bind the service via CLI

### Related issues

Done in preparation for https://github.com/cloud-gov/cg-ui/issues/304

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

This service was previously manually bound, this simply automates it (hopefully)
