### PR TITLE
fixes missing space roles, removes unnused role ranking

### DIFF
--- a/__tests__/controllers/controller-helpers.test.js
+++ b/__tests__/controllers/controller-helpers.test.js
@@ -39,16 +39,62 @@ describe('controller-helpers', () => {
     describe('when receiving a space specific result', () => {
       it('returns an array of RolesByUser objects with only space roles', () => {
         // act
-        const result = associateUsersWithRoles(mockUsersBySpace.resources);
-        const testUser = result['73193f8c-e03b-43c8-aeee-8670908899d2'];
+        const usersBySpaceRes = {
+          resources: [
+            {
+              guid: 'role1',
+              type: 'space_manager',
+              relationships: {
+                user: {
+                  data: {
+                    guid: 'user1',
+                  },
+                },
+                space: {
+                  data: {
+                    guid: 'space1',
+                  },
+                },
+                organization: {
+                  data: null,
+                },
+              },
+            },
+            {
+              guid: 'role2',
+              type: 'space_developer',
+              relationships: {
+                user: {
+                  data: {
+                    guid: 'user1',
+                  },
+                },
+                space: {
+                  data: {
+                    guid: 'space1',
+                  },
+                },
+                organization: {
+                  data: null,
+                },
+              },
+            },
+          ],
+        };
+        const result = associateUsersWithRoles(usersBySpaceRes.resources);
+        const testUser = result['user1'];
         // assert
         expect(testUser.org).toEqual([]);
-        expect(
-          testUser.space['dedb82bb-9f35-49f4-8ff9-7130ae2e3198'][0].guid
-        ).toEqual('dedb82bb-9f35-49f4-8ff9-7130ae2e3198');
-        expect(
-          testUser.space['dedb82bb-9f35-49f4-8ff9-7130ae2e3198'][0].role
-        ).toEqual('space_developer');
+        expect(testUser.space['space1']).toEqual([
+          {
+            guid: 'role1',
+            role: 'space_manager',
+          },
+          {
+            guid: 'role2',
+            role: 'space_developer',
+          },
+        ]);
       });
     });
 
@@ -70,7 +116,11 @@ describe('controller-helpers', () => {
         expect(testUser.space).toEqual({
           'dedb82bb-9f35-49f4-8ff9-7130ae2e3198': [
             {
-              guid: 'dedb82bb-9f35-49f4-8ff9-7130ae2e3198',
+              guid: '12ac7aa5-8a8e-48a4-9c90-a3b908c6e702',
+              role: 'space_manager',
+            },
+            {
+              guid: '1293d5ae-0266-413c-bacf-9f5474be984d',
               role: 'space_developer',
             },
           ],

--- a/__tests__/controllers/controllers.test.js
+++ b/__tests__/controllers/controllers.test.js
@@ -232,7 +232,11 @@ describe('controllers tests', () => {
           space: {
             'dedb82bb-9f35-49f4-8ff9-7130ae2e3198': [
               {
-                guid: 'dedb82bb-9f35-49f4-8ff9-7130ae2e3198',
+                guid: '12ac7aa5-8a8e-48a4-9c90-a3b908c6e702',
+                role: 'space_manager',
+              },
+              {
+                guid: '1293d5ae-0266-413c-bacf-9f5474be984d',
                 role: 'space_developer',
               },
             ],

--- a/controllers/controller-helpers.ts
+++ b/controllers/controller-helpers.ts
@@ -1,9 +1,4 @@
-import {
-  RolesByUser,
-  UserWithRoles,
-  RoleRanking,
-  UAAUser,
-} from './controller-types';
+import { RolesByUser, UserWithRoles, UAAUser } from './controller-types';
 import { ListRolesRes, RoleObj, UserObj } from '@/api/cf/cloudfoundry-types';
 import { addDays, randomDate } from '@/helpers/dates';
 import { cfRequestOptions } from '@/api/cf/cloudfoundry';
@@ -30,16 +25,21 @@ export function associateUsersWithRoles(roles: RoleObj[]): RolesByUser {
         allOrgRoleGuids: [],
       };
     }
-    // if the role is a space role, add to space role lisr
+    // if the role is a space role, add to space role list
     if (relation.space.data?.guid) {
       const spaceId = relation.space.data.guid;
       if (userObj[userId].space[spaceId]) {
         userObj[userId].space[spaceId].push({
-          guid: spaceId,
+          guid: resource.guid, // role guid
           role: resource.type,
         });
       } else {
-        userObj[userId].space[spaceId] = [];
+        userObj[userId].space[spaceId] = [
+          {
+            guid: resource.guid,
+            role: resource.type,
+          },
+        ];
       }
       // collect all space role guids needed for removing a user from an org
       userObj[userId].allSpaceRoleGuids.push(resource.guid);
@@ -56,20 +56,6 @@ export function associateUsersWithRoles(roles: RoleObj[]): RolesByUser {
     }
     return userObj;
   }, {} as RolesByUser);
-}
-
-const role_ranking: RoleRanking = {
-  space_manager: 4,
-  space_developer: 3,
-  space_auditor: 2,
-  space_supporter: 1,
-};
-
-export function rankRole(curRole: string, newRole: string): string {
-  if (role_ranking[newRole] > role_ranking[curRole]) {
-    return newRole;
-  }
-  return curRole;
 }
 
 // TODO delete associateUsersWithRolesTest and

--- a/controllers/controller-types.ts
+++ b/controllers/controller-types.ts
@@ -27,9 +27,6 @@ export interface RolesByUserRole {
   guid: string;
   role: RoleType;
 }
-export interface RoleRanking {
-  [roleType: string]: number;
-}
 
 export interface SpaceRoles {
   [spaceGuid: string]: RolesByUserRole[];


### PR DESCRIPTION
## Changes proposed in this pull request:

- `associateUsersWithRoles` function was only setting an empty array for first role rather than adding it
- removes space role ranking code which is no longer in use (can re-add if we want to keep it in the codebase for the future)
- changes controller tests to account for multiple space roles

Prior to changes the user display looked like this (org user row with space names but no roles listed under them)

![image](https://github.com/cloud-gov/cg-ui/assets/2480492/e2501eee-0638-4101-b5c3-a04a229364cf)

Now it looks like this (org user row with space names and roles listed under them)

![image](https://github.com/cloud-gov/cg-ui/assets/2480492/b55cf41a-1e94-434c-8041-e2abcc0a2c43)


### Related issues

None

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None
