### PR TITLE
parses vcap services as json

### DIFF
--- a/api/aws/s3.ts
+++ b/api/aws/s3.ts
@@ -10,11 +10,10 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3';
 
-const vcapServices = process.env.VCAP_SERVICES || (null as any);
-
-if (vcapServices) {
+if (process.env.VCAP_SERVICES) {
   // VCAP_SERVICES are only available if the application is deployed to CF,
   // in which case it should use the variables provided by the bound service
+  const vcapServices = JSON.parse(process.env.VCAP_SERVICES);
   const s3creds = vcapServices['s3'][0]['credentials'];
   process.env['AWS_ACCESS_KEY_ID'] = s3creds.access_key_id;
   process.env['AWS_SECRET_ACCESS_KEY'] = s3creds.secret_access_key;


### PR DESCRIPTION
## Changes proposed in this pull request:

- follows pattern from https://github.com/cloud-gov/cg-demos/blob/master/cg-identity/id-example.js#L15 to parse VCAP_SERVICES env variable as json
- hopefully unbreaks the deployment

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None
