### PR TITLE
Implements add user to org form

### DIFF
--- a/.env.cloud.example.yml
+++ b/.env.cloud.example.yml
@@ -8,6 +8,7 @@ CF_API_URL: https://replace_me/v3
 # oauth/uaa configs
 OAUTH_CLIENT_SECRET: replace_me
 UAA_ROOT_URL: replace_me
+NEXT_PUBLIC_USER_INVITE_URL: replace_me
 
 # db
 DB_NAME: cg-ui-datastore

--- a/.env.example.local
+++ b/.env.example.local
@@ -31,3 +31,8 @@ CF_API_TOKEN=token-without-bearer-at-beginning
 # S3_ACCESS_KEY_SECRET=
 # S3_BUCKET=
 # S3_REGION=
+
+# PUBLIC
+#   Prefixing a variable with NEXT_PUBLIC_ will make it available to the browser:
+#   https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser
+NEXT_PUBLIC_USER_INVITE_URL=https://account.dev.us-gov-west-1.aws-us-gov.cloud.gov/invite

--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,5 @@ UAA_LOGOUT_PATH=/logout.do
 
 CF_API_URL=https://example.com
 CF_API_TOKEN=placeholder
+
+NEXT_PUBLIC_USER_INVITE_URL=https://account.dev.us-gov-west-1.aws-us-gov.cloud.gov/invite

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
   "rules": {
     "no-unused-vars": 2,
     "prefer-const": 2,
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "react/no-unescaped-entities": "off"
   }
 }

--- a/__tests__/app/orgs/[orgId]/users/add/actions.test.js
+++ b/__tests__/app/orgs/[orgId]/users/add/actions.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
+import { addUserToOrg } from '@/app/orgs/[orgId]/users/add/actions';
+import { addRole } from '@/api/cf/cloudfoundry';
+
+/* global jest */
+/* eslint no-undef: "off" */
+jest.mock('../../../../../../api/cf/cloudfoundry');
+/* eslint no-undef: "error" */
+
+describe('addUserToOrg', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('when no email is found', () => {
+    it('returns an error controller result', async () => {
+      // setup
+      const formData = new FormData();
+      // act
+      const response = await addUserToOrg(formData);
+      const resJson = JSON.parse(response);
+      // expect
+      expect(resJson.meta.status).toEqual('error');
+      expect(resJson.meta.errors[0]).toEqual(
+        'No email found. Please enter a valid email and try again.'
+      );
+    });
+  });
+  describe('when email is invalid', () => {
+    it('returns an error controller result', async () => {
+      // setup
+      const formData = new FormData();
+      formData.append('add-user-to-org-form-email', 'foo');
+      // act
+      const response = await addUserToOrg(formData);
+      const resJson = JSON.parse(response);
+      // expect
+      expect(resJson.meta.status).toEqual('error');
+      expect(resJson.meta.errors[0]).toEqual(
+        'Email is missing an "@". Please enter a valid email and try again.'
+      );
+    });
+  });
+  describe('when API response is not okay', () => {
+    it('returns an error controller result', async () => {
+      // setup
+      const resBody = JSON.stringify({
+        errors: [
+          {
+            detail:
+              "user 'foo@bar.gov' already has 'organization_user' role in organization 'foo-org'",
+          },
+        ],
+      });
+      addRole.mockImplementation(() => {
+        return new Response(resBody, { status: 422 });
+      });
+      const formData = new FormData();
+      formData.append('add-user-to-org-form-email', 'foo@bar.gov');
+      formData.append('add-user-to-org-form-org', 'fooOrgId');
+      // act
+      const response = await addUserToOrg(formData);
+      const resJson = JSON.parse(response);
+      // expect
+      expect(resJson.meta.status).toEqual('error');
+      expect(resJson.meta.errors[0]).toEqual(
+        "user 'foo@bar.gov' already belongs to organization 'foo-org'"
+      );
+    });
+  });
+  describe('when API response is okay', () => {
+    it('returns a success controller result with user id in the payload', async () => {
+      // setup
+      const resBody = JSON.stringify({
+        relationships: {
+          user: {
+            data: {
+              guid: 'fooUserId',
+            },
+          },
+        },
+      });
+      addRole.mockImplementation(() => {
+        return new Response(resBody, { status: 201 });
+      });
+      const formData = new FormData();
+      formData.append('add-user-to-org-form-email', 'foo@bar.gov');
+      formData.append('add-user-to-org-form-org', 'fooOrgId');
+      // act
+      const response = await addUserToOrg(formData);
+      const resJson = JSON.parse(response);
+      // expect
+      expect(resJson.meta.status).toEqual('success');
+      expect(resJson.payload.userId).toEqual('fooUserId');
+    });
+  });
+});

--- a/__tests__/components/OrgActions/OrgActionsAddUser.test.js
+++ b/__tests__/components/OrgActions/OrgActionsAddUser.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, /*it,*/ xit } from '@jest/globals';
+import { waitFor, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OrgActionsAddUser } from '@/components/OrgActions/OrgActionsAddUser';
+import { addUserToOrg } from '@/app/orgs/[orgId]/users/add/actions';
+
+/* global jest */
+/* eslint no-undef: "off" */
+jest.mock('../../../app/orgs/[orgId]/users/add/actions');
+/* eslint no-undef: "error" */
+
+describe('<OrgActionsAddUser />', () => {
+  describe('when form submission fails', () => {
+    // TODO: cannot get forms to submit
+    xit('shows an error message', async () => {
+      // setup
+      const user = userEvent.setup();
+      const controllerErrorResponse = {
+        meta: {
+          status: 'error',
+          errors: ['foo example error'],
+        },
+      };
+      addUserToOrg.mockImplementation(() => controllerErrorResponse);
+      // render
+      render(
+        <OrgActionsAddUser orgId="fooOrgId" onCancelPath="/fooCancelPath" />
+      );
+      // act
+      const input = screen.getByRole('textbox');
+      await user.type(input, 'foo@example.com');
+      expect(screen.getByDisplayValue('foo@example.com')).toBeInTheDocument();
+      const submitBtn = screen.getByRole('button', { text: 'Add' });
+      await user.click(submitBtn);
+      // expect
+      await waitFor(() =>
+        expect(screen.getByText(/foo example error/)).toBeInTheDocument()
+      );
+    });
+  });
+});

--- a/__tests__/components/uswds/TextInput.test.js
+++ b/__tests__/components/uswds/TextInput.test.js
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { TextInput } from '@/components/uswds/TextInput';
+
+describe('<TextInput />', () => {
+  it('has a name', () => {
+    render(<TextInput id="foo-id" />);
+    const input = screen.getByRole('textbox');
+    expect(input.name).toEqual('foo-id');
+  });
+  it('has type="text" by default', () => {
+    render(<TextInput id="foo-id" />);
+    /* "textbox" is the default aria-label for input type="text" */
+    const input = screen.getByRole('textbox');
+    expect(input.type).toEqual('text');
+  });
+  it('has another type when another type is a prop', () => {
+    render(<TextInput id="foo-id" type="email" />);
+    const input = screen.getByRole('textbox');
+    expect(input.type).toEqual('email');
+  });
+  it('shows a related label when label text is a prop', () => {
+    render(<TextInput id="foo-id" labelText="Foo Label" />);
+    const input = screen.getByLabelText('Foo Label');
+    expect(input).toBeInTheDocument();
+  });
+  it('adds custom CSS classes to default classes when passed as a prop', () => {
+    render(<TextInput id="foo-id" className="foo-class" />);
+    const input = screen.getByRole('textbox');
+    expect(input.classList.contains('usa-input')).toBe(true);
+    expect(input.classList.contains('foo-class')).toBe(true);
+  });
+  it('shows an asterisk when required', () => {
+    render(<TextInput id="foo-id" labelText="Foo Label" required />);
+    const asterisk = screen.getByLabelText(/\*/);
+    expect(asterisk).toBeInTheDocument();
+  });
+  it('hides the asterisk when not required', () => {
+    render(<TextInput id="foo-id" labelText="Foo Label" />);
+    const asterisk = screen.queryByLabelText(/\*/);
+    expect(asterisk).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/helpers/text.test.js
+++ b/__tests__/helpers/text.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { underscoreToText } from '@/helpers/text';
+import { underscoreToText, emailIsValid } from '@/helpers/text';
 
 describe('underscoreToText', () => {
   it('removes underscores globally from a line of text', () => {
@@ -7,5 +7,14 @@ describe('underscoreToText', () => {
     const result = underscoreToText(input);
 
     expect(result).toEqual('foo bar baz');
+  });
+});
+
+describe('emailIsValid', () => {
+  it('returns false for an invalid email', () => {
+    expect(emailIsValid('foobar')).toBe(false);
+  });
+  it('returns true for a valid email', () => {
+    expect(emailIsValid('foo@example.com')).toBe(true);
   });
 });

--- a/api/cf/cloudfoundry-types.ts
+++ b/api/cf/cloudfoundry-types.ts
@@ -1,6 +1,6 @@
 export type RoleType =
   | 'organization_manager'
-  | 'organizion_user'
+  | 'organization_user'
   | 'organization_auditor'
   | 'organization_billing_manager'
   | 'space_manager'

--- a/app/orgs/[orgId]/page.tsx
+++ b/app/orgs/[orgId]/page.tsx
@@ -1,6 +1,15 @@
+/*
+  These route segment configs should bust Data and Route caching
+  So that the list of users is always up-to-date.
+  More info: https://nextjs.org/docs/app/building-your-application/caching#segment-config-options
+*/
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { UsersList } from '@/components/UsersList/UsersList';
 import { getOrgPage } from '@/controllers/controllers';
 import { PageHeader } from '@/components/PageHeader';
+import { AddUserButton } from '@/components/UsersList/AddUserButton';
 
 export default async function OrgPage({
   params,
@@ -12,11 +21,19 @@ export default async function OrgPage({
 
   return (
     <>
-      <PageHeader
-        heading="Manage users"
-        intro="Add and remove users from an org. Add users to spaces and set access
-        levels using role."
-      />
+      <PageHeader heading="Manage users">
+        <div className="tablet:display-flex">
+          <div className="flex-fill usa-prose">
+            <p className="tablet:margin-0">
+              Add and remove users from an org. Add users to spaces and set
+              access levels using role.
+            </p>
+          </div>
+          <div className="flex-align-self-end">
+            <AddUserButton orgId={params.orgId} />
+          </div>
+        </div>
+      </PageHeader>
       <UsersList
         users={users}
         roles={roles}

--- a/app/orgs/[orgId]/users/add/actions.tsx
+++ b/app/orgs/[orgId]/users/add/actions.tsx
@@ -1,0 +1,62 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { addRole } from '@/api/cf/cloudfoundry';
+import { RoleType } from '@/api/cf/cloudfoundry-types';
+import { ControllerResult } from '@/controllers/controller-types';
+import { emailIsValid } from '@/helpers/text';
+
+function formatError(errMsg: string): string {
+  return errMsg
+    .replace("already has 'organization_user' role in", 'already belongs to')
+    .replace('No user exists', 'No Cloud.gov account exists');
+}
+
+export async function addUserToOrg(formData: FormData) {
+  const email = formData.get('add-user-to-org-form-email') as string;
+  if (!email) {
+    /* Because we're passing from server to client, we must stringify the data */
+    return JSON.stringify({
+      meta: {
+        status: 'error',
+        errors: ['No email found. Please enter a valid email and try again.'],
+      },
+    } as ControllerResult);
+  }
+  if (!emailIsValid(email)) {
+    return JSON.stringify({
+      meta: {
+        status: 'error',
+        errors: [
+          'Email is missing an "@". Please enter a valid email and try again.',
+        ],
+      },
+    } as ControllerResult);
+  }
+  const orgId = formData.get('add-user-to-org-form-org') as string;
+  const res = await addRole({
+    orgGuid: orgId,
+    roleType: 'organization_user' as RoleType,
+    username: email,
+  });
+  const resJson = await res.json();
+  if (!res.ok) {
+    return JSON.stringify({
+      meta: {
+        status: 'error',
+        errors: resJson.errors.map((e: { detail: string }) =>
+          formatError(e.detail || '')
+        ),
+      },
+    } as ControllerResult);
+  }
+  if (process.env.NODE_ENV !== 'test') {
+    revalidatePath('/roles');
+  }
+  return JSON.stringify({
+    meta: { status: 'success' },
+    payload: {
+      userId: resJson.relationships.user.data.guid as string,
+    },
+  } as ControllerResult);
+}

--- a/app/orgs/[orgId]/users/add/layout.tsx
+++ b/app/orgs/[orgId]/users/add/layout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Link from 'next/link';
+
+export default function AddUserLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: {
+    orgId: string;
+  };
+}) {
+  return (
+    <>
+      <div className="desktop:display-flex border-bottom border-accent-warm-light padding-bottom-105 margin-bottom-4">
+        <Link href={`/orgs/${params.orgId}`} className="usa-link">
+          Manage users
+        </Link>{' '}
+        &nbsp; &gt; Add a user
+      </div>
+      {children}
+    </>
+  );
+}

--- a/app/orgs/[orgId]/users/add/loading.tsx
+++ b/app/orgs/[orgId]/users/add/loading.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function Loading() {
+  return <p>Loading the form...</p>;
+}

--- a/app/orgs/[orgId]/users/add/page.tsx
+++ b/app/orgs/[orgId]/users/add/page.tsx
@@ -1,0 +1,23 @@
+import { OrgActionsAddUser } from '@/components/OrgActions/OrgActionsAddUser';
+
+export default function AddUserPage({
+  params,
+}: {
+  params: {
+    orgId: string;
+  };
+}) {
+  return (
+    <>
+      <div className="maxw-mobile-lg">
+        <div className="usa-prose">
+          <h4>Add a user</h4>
+          <OrgActionsAddUser
+            orgId={params.orgId}
+            onCancelPath={`/orgs/${params.orgId}`}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/OrgActions/OrgActionsAddUser.tsx
+++ b/components/OrgActions/OrgActionsAddUser.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/uswds/Button';
+import { TextInput } from '@/components/uswds/TextInput';
+import { addUserToOrg } from '@/app/orgs/[orgId]/users/add/actions';
+import { Alert } from '@/components/uswds/Alert';
+
+type ActionStatus = 'default' | 'pending' | 'success' | 'error';
+
+export function OrgActionsAddUser({
+  orgId,
+  onCancelPath,
+}: {
+  orgId: string;
+  onCancelPath?: string;
+}) {
+  const [actionStatus, setActionStatus] = useState<ActionStatus>(
+    'default' as ActionStatus
+  );
+  const [actionErrors, setActionErrors] = useState<string[]>([] as string[]);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [emailInput, setEmailInput] = useState<string | null>(null);
+  const inviteUrl: string | undefined = process.env.NEXT_PUBLIC_USER_INVITE_URL;
+
+  const onSubmit = async (formData: FormData) => {
+    try {
+      Promise.resolve()
+        .then(() => {
+          // set state first
+          // I had to do this to get React to show the pending state before calling the form action
+          setActionStatus('pending' as ActionStatus);
+          setActionErrors([]);
+          setUserId(null);
+          setEmailInput(null);
+        })
+        .then(async () => {
+          const response = await addUserToOrg(formData);
+          const resObj = JSON.parse(response);
+          if (resObj.meta?.status === 'error') {
+            setActionStatus('error' as ActionStatus);
+            setActionErrors(resObj.meta?.errors || []);
+          }
+          if (resObj.meta?.status === 'success') {
+            const email = formData.get('add-user-to-org-form-email') as string;
+            setUserId(resObj.payload.userId);
+            setEmailInput(email);
+            setActionStatus('success' as ActionStatus);
+          }
+        });
+    } catch (e: any) {
+      setActionStatus('error' as ActionStatus);
+      setActionErrors([
+        'Something went wrong with the request. Please try again.',
+      ]);
+    }
+  };
+
+  return (
+    <form
+      action={onSubmit}
+      className="usa-form usa-form--large"
+      name="add-user-to-org-form"
+    >
+      <p>
+        The user must already have a Cloud.gov account.
+        {inviteUrl && (
+          <>
+            {' '}
+            If they don't, please invite them at{' '}
+            <Link href={inviteUrl}>{inviteUrl}</Link>.
+          </>
+        )}
+      </p>
+      <p>
+        Users are given the default role of <strong>User</strong>. You'll be
+        able to manage their roles once they're added.
+      </p>
+
+      {actionStatus === 'error' && (
+        <Alert type="error">{actionErrors.join(', ')}</Alert>
+      )}
+      {actionStatus === 'success' && (
+        <Alert type="success">
+          <strong>{emailInput || 'User'}</strong> has been added!
+          {userId && (
+            <>
+              <br />
+              <Link href={`/orgs/${orgId}/users/${userId}/org-roles`}>
+                Manage their organization roles
+              </Link>
+            </>
+          )}
+        </Alert>
+      )}
+
+      <fieldset className="usa-fieldset">
+        <legend className="usa-legend usa-sr-only">
+          <strong>Enter an email address</strong>
+        </legend>
+        <TextInput
+          required
+          type="email"
+          id="add-user-to-org-form-email"
+          labelText="Email (required)"
+        />
+      </fieldset>
+      <input type="hidden" name="add-user-to-org-form-org" value={orgId} />
+      <div className="margin-top-3">
+        {onCancelPath && (
+          <Link
+            href={onCancelPath}
+            className="usa-button usa-button--unstyled margin-right-4"
+          >
+            Cancel
+          </Link>
+        )}
+        <Button type="submit" disabled={actionStatus === 'pending'}>
+          Add
+        </Button>
+        {actionStatus === 'pending' && <p>Submission in progress...</p>}
+      </div>
+    </form>
+  );
+}

--- a/components/UsersList/AddUserButton.tsx
+++ b/components/UsersList/AddUserButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Button } from '@/components/uswds/Button';
+import { useRouter } from 'next/navigation';
+
+export function AddUserButton({ orgId }: { orgId: string }) {
+  const router = useRouter();
+  return (
+    <Button
+      className="margin-right-0"
+      onClick={() => {
+        router.push(`/orgs/${orgId}/users/add`);
+      }}
+    >
+      Add a user
+    </Button>
+  );
+}

--- a/components/uswds/TextInput.tsx
+++ b/components/uswds/TextInput.tsx
@@ -1,0 +1,43 @@
+import classnames from 'classnames';
+
+export function TextInput({
+  className,
+  id,
+  labelText,
+  required = false,
+  type = 'text',
+  ...inputProps
+}: {
+  id: string;
+  className?: string;
+  labelText?: string;
+  required?: boolean;
+  type?: string;
+}) {
+  const classes = classnames('usa-input', className);
+  return (
+    <>
+      {labelText && (
+        <label className="usa-label" htmlFor={id}>
+          {labelText}
+          {required && (
+            <abbr
+              title="required"
+              className="usa-hint usa-hint--required margin-left-2px"
+            >
+              *
+            </abbr>
+          )}
+        </label>
+      )}
+      <input
+        type={type}
+        className={classes}
+        id={id}
+        name={id}
+        required={required}
+        {...inputProps}
+      />
+    </>
+  );
+}

--- a/controllers/controller-helpers.ts
+++ b/controllers/controller-helpers.ts
@@ -1,7 +1,4 @@
-import {
-  RolesByUser,
-  SpaceRoleMap,
-} from './controller-types';
+import { RolesByUser, SpaceRoleMap } from './controller-types';
 import { RoleObj } from '@/api/cf/cloudfoundry-types';
 import { UserLogonInfoById } from '@/api/aws/s3-types';
 import { cfRequestOptions } from '@/api/cf/cloudfoundry';

--- a/controllers/controllers.ts
+++ b/controllers/controllers.ts
@@ -5,9 +5,7 @@
 import { revalidatePath } from 'next/cache';
 import * as CF from '@/api/cf/cloudfoundry';
 import { GetRoleArgs, SpaceObj, UserObj } from '@/api/cf/cloudfoundry-types';
-import {
-  ControllerResult,
-} from './controller-types';
+import { ControllerResult } from './controller-types';
 import {
   associateUsersWithRoles,
   defaultSpaceRoles,

--- a/helpers/text.tsx
+++ b/helpers/text.tsx
@@ -5,3 +5,12 @@ export function formatOrgRoleName(input: string): string {
 export function underscoreToText(input: string): string {
   return input.replace(/_/g, ' ').trim();
 }
+
+export function emailIsValid(text: string): boolean {
+  /* This is the same regex as W3's for email input types:
+  https://www.w3.org/TR/2012/WD-html-markup-20121025/input.email.html#form.data.emailaddress_xref2 */
+  const rgx = new RegExp(
+    '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$'
+  );
+  return rgx.test(text);
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds new page for adding a user to an org
- On page, adds form for adding user to org
- Adds button to /orgs/[orgId] page to go to add user page
- Also silences ESLint errors for rule: `react/no-unescaped-entities` because having to use html entities for every apostrophe in markup text was more annoying than useful

#### Notes
I'm stubbing out my test for `OrgActionsAddUser` because I'm still not about to simulate form submissions in tests. Any help there would be appreciated!

#### How to test

1. Go to an `/orgs/[orgId]` page and click "Add a user" button in top right corner
2. Try to add an email address of a current Cloud.gov user that's not part of this org
3. Click "Add" button

### Screenshots

#### Default state:

<img width="940" alt="Screenshot 2024-07-11 at 3 33 58 PM" src="https://github.com/user-attachments/assets/46b7f46e-a96c-4681-bac1-c387ac69de36">

#### Error state:

<img width="823" alt="Screenshot 2024-07-11 at 3 34 20 PM" src="https://github.com/user-attachments/assets/93397637-4f5d-46d3-9627-aa1a4f41cdd4">

#### Success state:

<img width="831" alt="Screenshot 2024-07-11 at 3 34 49 PM" src="https://github.com/user-attachments/assets/8c9187cf-e747-4ca3-83b2-c75cf242b464">


### Related issues

closes #332

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

adds form with server action
