### PR TITLE
Add a "skip to main content" link

### DIFF
--- a/__tests__/app/layout.test.js
+++ b/__tests__/app/layout.test.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import RootLayout from '@/app/layout';
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('<RootLayout />', () => {
+  it('focuses on skip to main content button first', async () => {
+    // setup
+    const user = userEvent.setup();
+    // render
+    /*
+      This shows a warning about how <html> can't be a child of <div>
+      because the layout has the <html> element and
+      React Testing Library renders into a div by default.
+      And passing a container option to render doesn't work
+      because <html> can't really be a child of any element.
+      But this doesn't affect functionality.
+    */
+    render(
+      <RootLayout>
+        <div>foo children</div>
+      </RootLayout>
+    );
+    // act
+    await user.tab();
+    // expect
+    const skipBtn = screen.getByText('Skip to main content');
+    expect(skipBtn).toHaveFocus();
+  });
+});

--- a/app/layout.js
+++ b/app/layout.js
@@ -14,6 +14,9 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className="bg-accent-warm-light">
+        <a className="usa-skipnav" href="#main-content">
+          Skip to main content
+        </a>
         <div className="border-bottom border-white">
           <Banner />
         </div>
@@ -22,7 +25,7 @@ export default function RootLayout({ children }) {
             <Sidebar />
           </div>
           <div className="desktop:grid-col-10 bg-white minh-viewport">
-            {children}
+            <main id="main-content">{children}</main>
           </div>
         </div>
         <Footer />

--- a/app/orgs/[orgId]/layout.tsx
+++ b/app/orgs/[orgId]/layout.tsx
@@ -17,12 +17,12 @@ export default async function OrgLayout({
       <LayoutHeader>
         {meta.status === 'success' ? payload.name : 'Org name not found'}
       </LayoutHeader>
-      <main className="padding-4">
+      <div className="padding-4">
         <div className="display-block padding-bottom-2">
           <Link href="/orgs">Back to all organizations</Link>
         </div>
         {children}
-      </main>
+      </div>
     </>
   );
 }

--- a/app/orgs/layout.tsx
+++ b/app/orgs/layout.tsx
@@ -8,5 +8,5 @@ export default function OrgsLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <main className="padding-4">{children}</main>;
+  return <div className="padding-4">{children}</div>;
 }

--- a/app/prototype/session/page.js
+++ b/app/prototype/session/page.js
@@ -23,10 +23,10 @@ export default function Page() {
   }, []);
 
   return (
-    <main>
+    <div>
       <h1>Sessions</h1>
       <SessionForm sessions={sessions} setSessionData={setSessionData} />
       <SessionList sessions={sessions} />
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds the USWDS "skip to main content" link to the top of the markup
  - Link is first item of focus for the site
  - Link is visually hidden unless tabbed to
  - Link takes you to `<main>` element
- Also moves main element to root layout

#### Screenshots

<img width="1440" alt="Screenshot 2024-07-12 at 9 50 12 AM" src="https://github.com/user-attachments/assets/414ecf87-f949-48d9-a42e-a10ec76a7dbe">

### Related issues

closes #328

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None - UI only
