### PR TITLE
pulls cf function args into objects to allow easier URL-ization

### DIFF
--- a/__tests__/api/cf/cloudfoundry.cfRequest.test.js
+++ b/__tests__/api/cf/cloudfoundry.cfRequest.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { cfRequest } from '@/api/cf/cloudfoundry';
+import { cfRequest } from '@/api/cf/cloudfoundry-helpers';
 import { request } from '@/api/api';
 
 /* global jest */

--- a/__tests__/api/cf/cloudfoundry.test.js
+++ b/__tests__/api/cf/cloudfoundry.test.js
@@ -40,7 +40,10 @@ describe('cloudfoundry tests', () => {
           .get('/apps?organization_guids=org1&include=space&per_page=5000')
           .reply(200, {});
 
-        const res = await getApps({ orgGuids: ['org1'], include: ['space'] });
+        const res = await getApps({
+          organizationGuids: ['org1'],
+          include: ['space'],
+        });
         expect(res.status).toEqual(200);
       });
     });
@@ -111,9 +114,11 @@ describe('cloudfoundry tests', () => {
     });
 
     describe('getSpaces', () => {
-      it('returns spaces available to the user', async () => {
-        nock(process.env.CF_API_URL).get('/spaces').reply(200, mockSpaces);
-        const res = await getSpaces();
+      it('when filtered by org guid, returns relevant spaces available to the user', async () => {
+        nock(process.env.CF_API_URL)
+          .get('/spaces?organization_guids=org1')
+          .reply(200, mockSpaces);
+        const res = await getSpaces({ organizationGuids: ['org1'] });
 
         expect(res.status).toEqual(200);
         expect(await res.json()).toEqual(mockSpaces);

--- a/__tests__/api/cf/roles.test.js
+++ b/__tests__/api/cf/roles.test.js
@@ -153,7 +153,7 @@ describe('cloudfoundry tests', () => {
         )
         .reply(200, mockRolesFilteredByOrgAndUser);
       const res = await getRoles({
-        orgGuids: ['validOrgGuid'],
+        organizationGuids: ['validOrgGuid'],
         userGuids: ['userGuid'],
       });
       expect(res.status).toEqual(200);

--- a/__tests__/api/cf/spaces.test.js
+++ b/__tests__/api/cf/spaces.test.js
@@ -40,7 +40,7 @@ describe('cloudfoundry tests', () => {
   describe('getSpaces', () => {
     it('returns spaces available to the user', async () => {
       nock(process.env.CF_API_URL).get('/spaces').reply(200, mockSpaces);
-      const res = await getSpaces();
+      const res = await getSpaces({});
       expect(res.status).toEqual(200);
       expect(await res.json()).toEqual(mockSpaces);
     });
@@ -49,7 +49,7 @@ describe('cloudfoundry tests', () => {
       nock(process.env.CF_API_URL)
         .get('/spaces?organization_guids=org1')
         .reply(200, mockSpaces);
-      const res = await getSpaces(['org1']);
+      const res = await getSpaces({ organizationGuids: ['org1'] });
       expect(res.status).toEqual(200);
       expect(await res.json()).toEqual(mockSpaces);
     });
@@ -58,7 +58,7 @@ describe('cloudfoundry tests', () => {
       nock(process.env.CF_API_URL)
         .get('/spaces?organization_guids=org1,org2')
         .reply(200, mockSpaces);
-      const res = await getSpaces(['org1', 'org2']);
+      const res = await getSpaces({ organizationGuids: ['org1', 'org2'] });
       expect(res.status).toEqual(200);
       expect(await res.json()).toEqual(mockSpaces);
     });

--- a/__tests__/api/cf/spaces.test.js
+++ b/__tests__/api/cf/spaces.test.js
@@ -40,7 +40,7 @@ describe('cloudfoundry tests', () => {
   describe('getSpaces', () => {
     it('returns spaces available to the user', async () => {
       nock(process.env.CF_API_URL).get('/spaces').reply(200, mockSpaces);
-      const res = await getSpaces({});
+      const res = await getSpaces();
       expect(res.status).toEqual(200);
       expect(await res.json()).toEqual(mockSpaces);
     });

--- a/__tests__/controllers/controllers.test.js
+++ b/__tests__/controllers/controllers.test.js
@@ -66,7 +66,7 @@ describe('controllers tests', () => {
     describe('if the s3 request fails', () => {
       it('returns normal response data with undefined user login info', async () => {
         // setup
-        const orgGuid = 'orgGuid';
+        const orgGuid = 'orgGuidS3Fails';
         const testSpaceGuids = {
           resources: [
             {
@@ -106,7 +106,7 @@ describe('controllers tests', () => {
     describe('if the CF requests succeed', () => {
       it('returns the expected controller result', async () => {
         // setup
-        const orgGuid = 'orgGuid';
+        const orgGuid = 'orgGuidSucceeded';
         const testSpaceGuids = {
           resources: [
             {

--- a/__tests__/helpers/text.test.js
+++ b/__tests__/helpers/text.test.js
@@ -1,20 +1,33 @@
 import { describe, expect, it } from '@jest/globals';
-import { underscoreToText, emailIsValid } from '@/helpers/text';
+import { camelToSnakeCase, emailIsValid, underscoreToText } from '@/helpers/text';
 
-describe('underscoreToText', () => {
-  it('removes underscores globally from a line of text', () => {
-    const input = '_foo_bar_baz_';
-    const result = underscoreToText(input);
-
-    expect(result).toEqual('foo bar baz');
+describe('text helpers', () => {
+  describe('camelToSnakeCase', () => {
+    it('replaces upcases with underscore and lowcase character', () => {
+      expect(camelToSnakeCase('organizationGuids')).toEqual(
+        'organization_guids'
+      );
+    });
+    it('leaves existing snake case alone', () => {
+      expect(camelToSnakeCase('space_guids')).toEqual('space_guids');
+    });
   });
-});
 
-describe('emailIsValid', () => {
-  it('returns false for an invalid email', () => {
-    expect(emailIsValid('foobar')).toBe(false);
+  describe('emailIsValid', () => {
+    it('returns false for an invalid email', () => {
+      expect(emailIsValid('foobar')).toBe(false);
+    });
+    it('returns true for a valid email', () => {
+      expect(emailIsValid('foo@example.com')).toBe(true);
+    });
   });
-  it('returns true for a valid email', () => {
-    expect(emailIsValid('foo@example.com')).toBe(true);
+
+  describe('underscoreToText', () => {
+    it('removes underscores globally from a line of text', () => {
+      const input = '_foo_bar_baz_';
+      const result = underscoreToText(input);
+
+      expect(result).toEqual('foo bar baz');
+    });
   });
 });

--- a/api/cf/cloudfoundry-helpers.ts
+++ b/api/cf/cloudfoundry-helpers.ts
@@ -1,0 +1,77 @@
+'use server';
+
+import { camelToSnakeCase } from '@/helpers/text';
+import { request } from '../api';
+import { getToken } from './token';
+
+type MethodType = 'delete' | 'get' | 'patch' | 'post';
+
+interface ApiRequestOptions {
+  method: MethodType;
+  headers: {
+    Authorization: string;
+    'Content-Type'?: string;
+  };
+  body?: any;
+}
+
+const CF_API_URL = process.env.CF_API_URL;
+
+export async function cfRequest(
+  path: string,
+  method: MethodType = 'get',
+  data?: any
+): Promise<Response> {
+  try {
+    const options = await cfRequestOptions(method, data);
+    return await request(CF_API_URL + path, options);
+  } catch (error: any) {
+    if (process.env.NODE_ENV == 'development') {
+      console.error(
+        `request to ${path} with method ${method} failed: ${error.statusCode} -- ${error.message}`
+      );
+    }
+    throw new Error(`something went wrong: ${error.message}`);
+  }
+}
+
+export async function cfRequestOptions(
+  method: MethodType,
+  data: any
+): Promise<ApiRequestOptions> {
+  const options: ApiRequestOptions = {
+    method: method,
+    headers: {
+      Authorization: `bearer ${getToken()}`,
+    },
+  };
+  if (data) {
+    options.body = JSON.stringify(data);
+    options.headers['Content-Type'] = 'application/json';
+  }
+  return options;
+}
+
+// converts arguments such as `organizationGuids=['org1', 'org2']`
+// to the format expected by CF API: '?organization_guids=org1, org2'
+export async function prepPathParams(options: {
+  [key: string]: Array<string> | string;
+}): Promise<string> {
+  const params = {} as any;
+
+  for (const [key, values] of Object.entries(options)) {
+    if (values === undefined) {
+      break;
+    }
+
+    var keyName = camelToSnakeCase(key);
+    if (Array.isArray(values)) {
+      params[keyName] = values.join(',');
+    } else {
+      params[keyName] = values;
+    }
+  }
+
+  const urlParams = new URLSearchParams(params);
+  return `?${urlParams.toString()}`;
+}

--- a/api/cf/cloudfoundry-types.ts
+++ b/api/cf/cloudfoundry-types.ts
@@ -19,20 +19,36 @@ export interface AddRoleArgs {
 }
 
 export interface GetAppArgs {
-  appGuids?: string[];
-  include?: string[];
-  orgGuids?: string[];
+  // guids refers to application guids
+  guids?: string[];
+  names?: string[];
+  include?: Array<'space' | 'space.organization'>;
+  organizationGuids?: string[];
+  perPage?: string;
   spaceGuids?: string[];
 }
 
 export interface GetRoleArgs {
-  include?: string[];
-  orgGuids?: string[];
+  // guids refers to role guids
+  guids?: string[];
+  types?: RoleType[];
+  include?: Array<'user' | 'space' | 'organization'>;
+  organizationGuids?: string[];
+  perPage?: string;
   spaceGuids?: string[];
   userGuids?: string[];
 }
 
-/* INDIVIDUAL API OBJECTS */
+export interface GetSpaceArgs {
+  // guids refers to space guids
+  guids?: string[];
+  include?: Array<'organization'>;
+  names?: string[];
+  organizationGuids?: string[];
+  perPage?: string;
+}
+
+/* INDIVIDUAL API RESPONSE OBJECTS */
 
 export interface AppObj {
   guid: string;

--- a/api/cf/cloudfoundry.ts
+++ b/api/cf/cloudfoundry.ts
@@ -19,7 +19,7 @@ import {
 
 // APPS
 
-export async function getApps({ ...args }: GetAppArgs): Promise<Response> {
+export async function getApps({ ...args }: GetAppArgs = {}): Promise<Response> {
   // set per_page to maximum allowed value
   const pathParams = await prepPathParams({ ...args, per_page: '5000' });
   return await cfRequest('/apps' + pathParams);
@@ -76,7 +76,9 @@ export async function deleteRole(roleGuid: string): Promise<Response> {
 // note: filters work as an "and" in the CF list roles API
 // therefore, if you try to filter by both an org and a space GUID you
 // will receive 0 results
-export async function getRoles({ ...args }: GetRoleArgs): Promise<Response> {
+export async function getRoles({
+  ...args
+}: GetRoleArgs = {}): Promise<Response> {
   // params are all comma separated lists
   const pathParams = await prepPathParams({ ...args, per_page: '5000' });
   return await cfRequest('/roles' + pathParams);
@@ -88,7 +90,9 @@ export async function getSpace(guid: string): Promise<Response> {
   return await cfRequest('/spaces/' + guid, 'get');
 }
 
-export async function getSpaces({ ...args }: GetSpaceArgs): Promise<Response> {
+export async function getSpaces({
+  ...args
+}: GetSpaceArgs = {}): Promise<Response> {
   const pathParams = await prepPathParams(args);
   return await cfRequest('/spaces' + pathParams);
 }

--- a/controllers/controller-helpers.ts
+++ b/controllers/controller-helpers.ts
@@ -1,7 +1,7 @@
 import { RolesByUser, SpaceRoleMap } from './controller-types';
 import { RoleObj } from '@/api/cf/cloudfoundry-types';
 import { UserLogonInfoById } from '@/api/aws/s3-types';
-import { cfRequestOptions } from '@/api/cf/cloudfoundry';
+import { cfRequestOptions } from '@/api/cf/cloudfoundry-helpers';
 import { request } from '@/api/api';
 import { delay } from '@/helpers/timeout';
 

--- a/controllers/prototype-controller.ts
+++ b/controllers/prototype-controller.ts
@@ -183,8 +183,8 @@ export async function getOrgs(): Promise<Result> {
 export async function getOrgPage(orgGuid: string): Promise<ControllerResult> {
   const [orgRes, usersRes, spacesRes] = await Promise.all([
     CF.getOrg(orgGuid),
-    CF.getRoles({ orgGuids: [orgGuid], include: ['user'] }),
-    CF.getSpaces([orgGuid]),
+    CF.getRoles({ organizationGuids: [orgGuid], include: ['user'] }),
+    CF.getSpaces({ organizationGuids: [orgGuid] }),
   ]);
   [orgRes, usersRes, spacesRes].map((res) => {
     if (!res.ok) {
@@ -266,7 +266,9 @@ async function deleteGroupUser(
     const args: GetRoleArgs = {
       userGuids: [userGuid],
     };
-    groupType === 'org' ? (args.orgGuids = guids) : (args.spaceGuids = guids);
+    groupType === 'org'
+      ? (args.organizationGuids = guids)
+      : (args.spaceGuids = guids);
     const roleRes = await CF.getRoles(args);
 
     if (!roleRes.ok) {

--- a/helpers/text.tsx
+++ b/helpers/text.tsx
@@ -1,3 +1,10 @@
+export function camelToSnakeCase(input: string): string {
+  function replacer(match: string) {
+    return `_${match.toLowerCase()}`;
+  }
+  return input.replace(/[A-Z]/g, replacer);
+}
+
 export function formatOrgRoleName(input: string): string {
   return underscoreToText(input).replace('organization', 'org');
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

When I started thinking about how to build up the CF endpoints to support an app detail page, I decided it was a good time to consolidate the places in the cloudfoundry file where different parameters were being passed in (like filters for org GUID, includes, etc). The "args" continue to be informed by interfaces but the search URL parameterization happens in one place.

One downside is that now we have to say `getSpaces({})` if there are no arguments, instead of just `getSpaces()`.

- fills out the possible arguments using the CF API options (did not include all of them but at least more of them)
- updates throughout the app and tests where the altered functions are being called

### Related issues

None at the moment

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

No new considerations
