### PR TITLE
Adds label and removes time (but keeps date) for org member last login

### DIFF
--- a/__tests__/components/UsersList/UsersListLastLogin.test.js
+++ b/__tests__/components/UsersList/UsersListLastLogin.test.js
@@ -16,7 +16,7 @@ describe('UsersListLastLogin', () => {
       };
       render(<UsersListLastLogin userLogonInfo={info} />);
 
-      const content = screen.queryByText('Never logged in');
+      const content = screen.queryByText('Never');
       expect(content).toBeInTheDocument();
     });
   });
@@ -50,11 +50,9 @@ describe('UsersListLastLogin', () => {
       //act
       render(<UsersListLastLogin userLogonInfo={info} />);
       // query
-      const time = screen.queryByText(/\d{2}:\d{2} [A|P]M/);
       const date = screen.queryByText(/[a-zA-Z] \d+, \d{4}/);
       const expiryText = screen.queryByText('Login expires in 88 days');
       // assert
-      expect(time).toBeInTheDocument();
       expect(date).toBeInTheDocument();
       expect(expiryText).toBeInTheDocument();
     });

--- a/__tests__/helpers/text.test.js
+++ b/__tests__/helpers/text.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { camelToSnakeCase, emailIsValid, underscoreToText } from '@/helpers/text';
+import {
+  camelToSnakeCase,
+  emailIsValid,
+  underscoreToText,
+} from '@/helpers/text';
 
 describe('text helpers', () => {
   describe('camelToSnakeCase', () => {

--- a/components/UsersList/UsersListLastLogin.tsx
+++ b/components/UsersList/UsersListLastLogin.tsx
@@ -32,13 +32,16 @@ export function UsersListLastLogin({
   return (
     <div className="text-right text-base" aria-label="last login time">
       <div>
-        {!timestamp && 'Never logged in'}
+        <h3 className="margin-0 font-body-2xs text-semibold text-base font-heading-sm">
+          Last logged in
+        </h3>
+        <br />
+        {!timestamp && 'Never'}
         {timestamp && isExpired && 'Login expired'}
-        {showTimestamp && formatTime(timestamp)}
       </div>
       <div aria-label="last login date">
         {(!timestamp || (timestamp && isExpired)) && (
-          <button className="usa-button usa-button--unstyled">
+          <button className="usa-button usa-button--unstyled padding-top-1">
             Resend invite
           </button>
         )}


### PR DESCRIPTION
## Changes proposed in this pull request:

- On org members page (`/org/[orgId]`), adds a label for last login area
- removes time but keeps date for last login area

### screenshots

In a row:

![Screenshot 2024-07-17 at 4 35 57 PM](https://github.com/user-attachments/assets/8a6d6939-4c4a-478f-ab9c-0b300a611d3e)

New variants:

![Screenshot 2024-07-17 at 4 28 26 PM](https://github.com/user-attachments/assets/fd64e292-c1bc-45b4-a76b-861b441b8010)



### Related issues

Closes #365 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI change only
