### PR TITLE
rudimentary display of org usage and quota

### DIFF
--- a/api/cf/cloudfoundry-helpers.ts
+++ b/api/cf/cloudfoundry-helpers.ts
@@ -55,7 +55,7 @@ export async function cfRequestOptions(
 // converts arguments such as `organizationGuids=['org1', 'org2']`
 // to the format expected by CF API: '?organization_guids=org1, org2'
 export async function prepPathParams(options: {
-  [key: string]: Array<string> | string;
+  [key: string]: Array<string> | string | boolean;
 }): Promise<string> {
   const params = {} as any;
 

--- a/api/cf/cloudfoundry-types.ts
+++ b/api/cf/cloudfoundry-types.ts
@@ -28,6 +28,13 @@ export interface GetAppArgs {
   spaceGuids?: string[];
 }
 
+export interface GetOrgQuotasArgs {
+  // guids and names refer to quota guids
+  guids?: string[];
+  names?: string[];
+  organizationGuids?: string[];
+}
+
 export interface GetRoleArgs {
   // guids refers to role guids
   guids?: string[];
@@ -37,6 +44,45 @@ export interface GetRoleArgs {
   perPage?: string;
   spaceGuids?: string[];
   userGuids?: string[];
+}
+
+export interface GetServiceInstancesArgs {
+  // guids and names refer to the service instances
+  guids?: string[];
+  names?: string[];
+  organizationGuids?: string[];
+  perPage?: string;
+  servicePlanGuids?: string[];
+  servicePlanNames?: string[];
+  spaceGuids?: string[];
+  type?: Array<'managed' | 'user-provided'>;
+  // other arguments not yet implemented
+  //   fields (https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#fields-parameter)
+  //   labelSelector (https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#labels-and-selectors)
+  //   createdAts (timestamps and relational operators)
+  //   updatedAts (timestamps and relational operators)
+}
+
+// space and org filters do not filter out plans that are public, only those restricted to an organization
+export interface GetServicePlansArgs {
+  // guids and names refer to the service plans
+  guids?: string[];
+  names?: string[];
+  available?: boolean;
+  brokerCatalogIds?: string[];
+  organizationGuids?: string[];
+  serviceBrokerGuids?: string[];
+  serviceBrokerNames?: string[];
+  serviceOfferingGuids?: string[];
+  serviceOfferingNames?: string[];
+  serviceInstanceGuids?: string[];
+  spaceGuids?: string[];
+  include?: Array<'space.organization' | 'service_offering'>;
+  // other arguments not yet implemented
+  //   fields (https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#fields-parameter)
+  //   labelSelector (https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#labels-and-selectors)
+  //   createdAts (timestamps and relational operators)
+  //   updatedAts (timestamps and relational operators)
 }
 
 export interface GetSpaceArgs {

--- a/api/cf/cloudfoundry-types.ts
+++ b/api/cf/cloudfoundry-types.ts
@@ -154,6 +154,74 @@ export interface RoleObj {
   links: any;
 }
 
+export interface ServiceInstanceObj {
+  guid: string;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  type: 'managed' | 'user-provided';
+  tags: string[];
+  last_operation: {
+    type: 'create' | 'update' | 'delete';
+    state: 'initial' | 'in progress' | 'succeeded' | 'failed';
+    description: string;
+    created_at: string;
+    updated_at: string;
+  };
+  relationships: {
+    // service plan only shown if type managed
+    service_plan?: {
+      data: {
+        guid: string;
+      };
+    };
+    space: {
+      data: {
+        guid: string;
+      };
+    };
+  };
+  metadata: any;
+  links: any;
+  // syslog and route only if type user-provided
+  syslog_drain_url?: string;
+  route_service_url?: string;
+  // following only if type managed
+  maintenance_info?: any;
+  upgrade_available?: boolean;
+  dashboard_url?: string;
+}
+
+export interface ServicePlanObj {
+  guid: string;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  visibility_type: 'public' | 'admin' | 'organization' | 'space';
+  available: boolean;
+  free: boolean;
+  description: string;
+  relationships: {
+    service_offering: {
+      data: {
+        guid: string;
+      };
+    };
+    space: {
+      data: {
+        guid: string;
+      };
+    };
+  };
+  // TODO update if we start using the below
+  costs: any;
+  maintenance_info: any;
+  broker_catalog: any;
+  schemas: any;
+  metadata: any;
+  links: any;
+}
+
 export interface SpaceObj {
   guid: string;
   created_at: string;

--- a/api/cf/cloudfoundry.ts
+++ b/api/cf/cloudfoundry.ts
@@ -9,7 +9,10 @@ import {
   AddRoleApiData,
   AddRoleArgs,
   GetAppArgs,
+  GetOrgQuotasArgs,
   GetRoleArgs,
+  GetServiceInstancesArgs,
+  GetServicePlansArgs,
   GetSpaceArgs,
 } from './cloudfoundry-types';
 
@@ -29,6 +32,18 @@ export async function getApps({ ...args }: GetAppArgs = {}): Promise<Response> {
 
 export async function getOrg(guid: string): Promise<Response> {
   return await cfRequest('/organizations/' + guid, 'get');
+}
+
+// 1 org has 1 quota; 1 quota may apply to many orgs
+export async function getOrgQuotas({
+  ...args
+}: GetOrgQuotasArgs = {}): Promise<Response> {
+  const pathParams = await prepPathParams(args);
+  return await cfRequest('/organization_quotas' + pathParams);
+}
+
+export async function getOrgUsageSummary(guid: string): Promise<Response> {
+  return await cfRequest(`/organizations/${guid}/usage_summary`);
 }
 
 export async function getOrgs(): Promise<Response> {
@@ -79,9 +94,26 @@ export async function deleteRole(roleGuid: string): Promise<Response> {
 export async function getRoles({
   ...args
 }: GetRoleArgs = {}): Promise<Response> {
-  // params are all comma separated lists
   const pathParams = await prepPathParams({ ...args, per_page: '5000' });
   return await cfRequest('/roles' + pathParams);
+}
+
+// SERVICES AND SERVICE RELATED
+
+// note: there are several other query arguments available for this endpoint which
+// have not been implemented involving subfields, labels, and time ranges
+export async function getServiceInstances({
+  ...args
+}: GetServiceInstancesArgs = {}): Promise<Response> {
+  const pathParams = await prepPathParams(args);
+  return await cfRequest('/service_instances' + pathParams);
+}
+
+export async function getServicePlans({
+  ...args
+}: GetServicePlansArgs = {}): Promise<Response> {
+  const pathParams = await prepPathParams(args);
+  return await cfRequest('/service_plans' + pathParams);
 }
 
 // SPACES

--- a/app/orgs/[orgId]/apps/page.tsx
+++ b/app/orgs/[orgId]/apps/page.tsx
@@ -2,7 +2,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { getOrgAppsPage } from '@/controllers/controllers';
 import { AppsList } from '@/components/AppsList/AppsList';
 
-export default async function OrgPage({
+export default async function OrgAppsPage({
   params,
 }: {
   params: { orgId: string };

--- a/app/orgs/[orgId]/usage/page.tsx
+++ b/app/orgs/[orgId]/usage/page.tsx
@@ -1,8 +1,16 @@
+import {
+  ServiceInstanceObj,
+  ServicePlanObj,
+} from '@/api/cf/cloudfoundry-types';
 import { PageHeader } from '@/components/PageHeader';
 import { getOrgUsagePage } from '@/controllers/controllers';
 import { formatDate } from '@/helpers/dates';
 
-function formatCost(plan: any): string {
+interface ServicePlanLookup {
+  [index: string]: ServicePlanObj;
+}
+
+function formatCost(plan: ServicePlanObj): string {
   const firstCost = plan.costs[0];
   if (plan.free === true) {
     return 'Free';
@@ -21,7 +29,13 @@ function formatLimits(limit: string | null) {
   return limit;
 }
 
-function Service({ service, plans }: { service: any; plans: any }) {
+function Service({
+  service,
+  plans,
+}: {
+  service: ServiceInstanceObj;
+  plans: ServicePlanLookup;
+}) {
   if (service.relationships.service_plan) {
     const plan = plans[service.relationships.service_plan.data.guid];
     return (
@@ -58,8 +72,8 @@ export default async function OrgUsagePage({
   const { payload } = await getOrgUsagePage(params.orgId);
   const quota = payload.quota;
   const usage = payload.usage.usage_summary;
-  const svcInstances = payload.services.instances;
-  const svcPlans = payload.services.plans;
+  const svcInstances = payload.services.instances as Array<ServiceInstanceObj>;
+  const svcPlans = payload.services.plans as ServicePlanLookup;
 
   return (
     <>
@@ -108,7 +122,7 @@ export default async function OrgUsagePage({
       for more information about quota limits that we may want to reveal to users of an organization */}
 
       <h2>Services overview</h2>
-      {svcInstances.map((svc: any) => {
+      {svcInstances.map((svc: ServiceInstanceObj) => {
         return (
           <>
             <Service service={svc} plans={svcPlans} key={svc.guid} />

--- a/app/orgs/[orgId]/usage/page.tsx
+++ b/app/orgs/[orgId]/usage/page.tsx
@@ -1,0 +1,120 @@
+import { PageHeader } from '@/components/PageHeader';
+import { getOrgUsagePage } from '@/controllers/controllers';
+import { formatDate } from '@/helpers/dates';
+
+function formatCost(plan: any): string {
+  const firstCost = plan.costs[0];
+  if (plan.free === true) {
+    return 'Free';
+  } else if (firstCost) {
+    const currency = firstCost.currency === 'USD' ? '$' : firstCost.currency;
+    return `${currency}${firstCost.amount} ${firstCost.unit.toLowerCase()}`;
+  } else {
+    return 'No pricing available';
+  }
+}
+
+function formatLimits(limit: string | null) {
+  if (limit === null) {
+    return 'None';
+  }
+  return limit;
+}
+
+function Service({ service, plans }: { service: any; plans: any }) {
+  if (service.relationships.service_plan) {
+    const plan = plans[service.relationships.service_plan.data.guid];
+    return (
+      <>
+        <h3>
+          {service.name} ({plan.name})
+        </h3>
+        {service.upgrade_available && <dd>Upgrade available!</dd>}
+        <ul>
+          <li>{plan.description}</li>
+          <li>Created: {formatDate(service.created_at)}</li>
+          <li>Cost: {formatCost(plan)}</li>
+        </ul>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <h3>{service.name} (no associated service plan)</h3>
+        {service.upgrade_available && <dd>Upgrade available!</dd>}
+        <ul>
+          <li>Created: {formatDate(service.created_at)}</li>
+        </ul>
+      </>
+    );
+  }
+}
+
+export default async function OrgUsagePage({
+  params,
+}: {
+  params: { orgId: string };
+}) {
+  const { payload } = await getOrgUsagePage(params.orgId);
+  const quota = payload.quota;
+  const usage = payload.usage.usage_summary;
+  const svcInstances = payload.services.instances;
+  const svcPlans = payload.services.plans;
+
+  return (
+    <>
+      <PageHeader
+        heading="View organization usage"
+        intro="View a summary of your organization's resource usage and limits"
+      />
+
+      <h2>Organization usage overview</h2>
+
+      <dl>
+        <dt>Application instances</dt>
+        <dd>Current: {usage.started_instances} active instances</dd>
+        <dd>Limit: {formatLimits(quota.apps.total_instances)}</dd>
+
+        <dt>Total memory</dt>
+        <dd>Current: {usage.memory_in_mb} mb</dd>
+        <dd>Limit: {quota.apps.total_memory_in_mb} mb</dd>
+
+        <dt>Routes</dt>
+        <dd>Current: {usage.routes}</dd>
+        <dd>Limit: {formatLimits(quota.routes.total_routes)}</dd>
+
+        <dt>Reserved ports</dt>
+        <dd>Current: {usage.reserved_ports}</dd>
+        <dd>Limit: {formatLimits(quota.routes.total_reserved_ports)}</dd>
+
+        <dt>Service instances</dt>
+        <dd>Current: {usage.service_instances}</dd>
+        <dd>Limit: {formatLimits(quota.services.total_service_instances)}</dd>
+
+        <dt>Domains</dt>
+        <dd>Current: {usage.domains}</dd>
+        <dd>Limit: {formatLimits(quota.domains.total_domains)}</dd>
+
+        <dt>Per app tasks</dt>
+        <dd>Current: {usage.per_app_tasks}</dd>
+        <dd>Limit: {formatLimits(quota.apps.per_app_tasks)}</dd>
+
+        <dt>Service keys</dt>
+        <dd>Current: {usage.service_keys}</dd>
+        <dd>Limit: {formatLimits(quota.services.total_service_keys)}</dd>
+      </dl>
+
+      {/* See https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#organization-quotas
+      for more information about quota limits that we may want to reveal to users of an organization */}
+
+      <h2>Services overview</h2>
+      {svcInstances.map((svc: any) => {
+        return (
+          <>
+            <Service service={svc} plans={svcPlans} key={svc.guid} />
+          </>
+        );
+      })}
+    </>
+  );
+}

--- a/components/OrganizationsList/OrganizationsListItem.tsx
+++ b/components/OrganizationsList/OrganizationsListItem.tsx
@@ -34,6 +34,11 @@ export function OrganizationsListItem({ org }: { org: OrgObj }) {
                     View applications
                   </Link>
                 </li>
+                <li>
+                  <Link href={`/orgs/${org.guid}/usage`} className="usa-link">
+                    View usage
+                  </Link>
+                </li>
               </ul>
             </div>
           </GridListItemBottomCenter>

--- a/controllers/controllers.ts
+++ b/controllers/controllers.ts
@@ -4,7 +4,11 @@
 /***/
 import { revalidatePath } from 'next/cache';
 import * as CF from '@/api/cf/cloudfoundry';
-import { SpaceObj, UserObj } from '@/api/cf/cloudfoundry-types';
+import {
+  ServiceInstanceObj,
+  SpaceObj,
+  UserObj,
+} from '@/api/cf/cloudfoundry-types';
 import { ControllerResult } from './controller-types';
 import {
   associateUsersWithRoles,
@@ -183,7 +187,9 @@ export async function getOrgUsagePage(
 
   const quotas = await orgQuotasRes.json();
   const svcInstances = await svcInstancesRes.json();
-  const svcPlanGuids = svcInstances.resources.map(function (instance: any) {
+  const svcPlanGuids = svcInstances.resources.map(function (
+    instance: ServiceInstanceObj
+  ) {
     // Note: some instances do not appear to have associated plans
     if (instance.relationships.service_plan) {
       return instance.relationships.service_plan.data.guid;


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds requests to cloud foundry and argument interfaces for org usage and org service related information
- roughs in a controller and UI which are not intended for long term use (UI is not tested, as we can assume it will be entirely changing)

### Screenshots and walkthrough

From the list of orgs, click the "usage" link.

The first half of the usage page is a mashup of two pieces of information:  org usage summary and org quota. The quota can be user-created or using cloud.gov org defaults.

![image](https://github.com/user-attachments/assets/1d430fef-fcd9-424a-8f69-02755ba36b02)

At the bottom of the page is a list of services that are operating within this organization.  This information is populated by service instances specific to this org and their matching service plans.  Service plans may potentially have multiple costs associated with them, but for now I'm just grabbing the first one. Additionally, some service plans have additional costs which are incurred by the type of usage, like storage space or CPU, etc, but I decided not to try to capture this information right now for the following reasons:

1. The pricing info is in the cloud documentation, NOT through the API as far as I could discern
2. I was unable to find any service plans / brokers with the flag that would allow me to query the parameters set on an instance (such as the storage space)
3. I didn't want to spend too much time focusing on the current billing model

![image](https://github.com/user-attachments/assets/1022de92-6131-4561-95c5-ab27e5bebbb1)


### Related issues

closes #362 

### Submitter checklist

- [X] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

No additional, similar pattern as previous endpoint interactions
