### PR TITLE
experimentation with code coverage through jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,11 +8,20 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const config = {
+  // CODE COVERAGE
   collectCoverage: true,
-  coverageDirectory: './coverage',
-  coverageProvider: 'babel',
   collectCoverageFrom: ['**/*.{ts,tsx}', '!next-env.d.ts'],
+  coverageDirectory: './coverage',
   coveragePathIgnorePatterns: ['/node_modules/', '/app/prototype/', '/.next/'],
+  coverageProvider: 'babel',
+  coverageThreshold: {
+    global: {
+      branches: 45,
+      functions: 60,
+      lines: 60,
+    },
+  },
+
   // testEnvironment: node works for api testing, but to test anything needing a browser, like React components, set @jest-environment to jsdom in the file: https://jestjs.io/docs/configuration#testenvironment-string
   testEnvironment: 'node',
   // Add more setup options before each test is run

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,11 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const config = {
-  coverageProvider: 'v8',
+  collectCoverage: true,
+  coverageDirectory: './coverage',
+  coverageProvider: 'babel',
+  collectCoverageFrom: ['**/*.{ts,tsx}', '!next-env.d.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/app/prototype/', '/.next/'],
   // testEnvironment: node works for api testing, but to test anything needing a browser, like React components, set @jest-environment to jsdom in the file: https://jestjs.io/docs/configuration#testenvironment-string
   testEnvironment: 'node',
   // Add more setup options before each test is run


### PR DESCRIPTION
## Changes proposed in this pull request:

I enabled code coverage reports via jest to see how it works and what our current coverage levels are.  I did not enable a failure threshold, but jest allows us to configure different thresholds for the entire app vs functions vs groups of lines, which we could use with our CI to auto-fail anything not passing those thresholds without adding any additional steps to the CI itself.  See https://jestjs.io/docs/configuration#coveragethreshold-object

These are the types of results I am currently getting with the default reporter:

[alt: code coverage report with low 60% for all files, decent coverage for the api directory, and then very little to no test coverage for the apps/orgs directory. A list of uncovered line numbers accompanies the results.]

![image](https://github.com/user-attachments/assets/bb47e2bf-f950-4fcc-b6cb-433641b2c9b4)


I have the following questions:

1. Do we want to experiment with any other tools or just roll ahead with jest?
2. What files do we want to exclude from test coverage? Any additional from what I already excluded?
3. What thresholds do we want to set?

### Run code coverage

Just run `npm run test` like normal (you will need the docker db and uaa running) and at the end you will get a report in your console.

### Related issues

part of #126 (not completed because we're lacking thresholds and also we need to beef up tests to meet thresholds, likely)

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None that I am aware of
