### PR TITLE
Add search functionality for users list (proof of concept)

### DIFF
--- a/__tests__/components/ListSearchInput.test.js
+++ b/__tests__/components/ListSearchInput.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest, describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ListSearchInput } from '@/components/ListSearchInput';
+
+describe('ListSearchInput', () => {
+  describe('DOM elements', () => {
+    it('has a form with a search role', () => {
+      render(<ListSearchInput onSubmit={() => {}} />);
+      const form = screen.queryByRole('search');
+      expect(form).toBeInTheDocument();
+    });
+    it('has a label for the input', () => {
+      render(<ListSearchInput onSubmit={() => {}} />);
+      const inputByLabel = screen.queryByLabelText('Search');
+      expect(inputByLabel).toBeInTheDocument();
+    });
+    it('has a submit button', () => {
+      render(<ListSearchInput onSubmit={() => {}} />);
+      const submitBtn = screen.queryByRole('button', { type: 'submit' });
+      expect(submitBtn).toBeInTheDocument();
+    });
+  });
+  describe('actions', () => {
+    it('on submit, calls onSubmit prop with search term', async () => {
+      // setup
+      const user = userEvent.setup();
+      const onSubmit = jest.fn();
+      // render
+      render(<ListSearchInput onSubmit={onSubmit} />);
+      // act
+      const input = screen.getByLabelText('Search');
+      input.focus();
+      await user.keyboard('foo');
+      await user.keyboard('{enter}');
+      // expect
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith('foo');
+    });
+  });
+});

--- a/__tests__/components/UsersList/UsersList.test.js
+++ b/__tests__/components/UsersList/UsersList.test.js
@@ -100,7 +100,9 @@ describe('UsersList', () => {
         />
       );
       // act
-      const input = screen.getByLabelText('Search');
+      const input = screen.getByLabelText(
+        'search the list of users by username'
+      );
       input.focus();
       await user.keyboard('c us');
       await user.keyboard('{enter}');

--- a/__tests__/components/UsersList/UsersList.test.js
+++ b/__tests__/components/UsersList/UsersList.test.js
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { UsersList } from '@/components/UsersList/UsersList';
 
 const mockUsers = [
@@ -83,5 +84,37 @@ describe('UsersList', () => {
     expect(list[0]).toHaveTextContent(/a username 2/);
     expect(list[1]).toHaveTextContent(/b username 3/);
     expect(list[2]).toHaveTextContent(/c username 1/);
+  });
+
+  describe('filtering users', () => {
+    it('filters the expected users when search term is submitted', async () => {
+      // setup
+      const user = userEvent.setup();
+      // act
+      render(
+        <UsersList
+          users={mockUsers}
+          roles={mockRoles}
+          spaces={mockSpaces}
+          userLoginInfo={mockUserLogonTime}
+        />
+      );
+      // act
+      const input = screen.getByLabelText('Search');
+      input.focus();
+      await user.keyboard('c us');
+      await user.keyboard('{enter}');
+      // query
+      const list = screen.getAllByRole('listitem');
+      // expect list to be filtered
+      expect(list.length).toEqual(1);
+      expect(list[0]).toHaveTextContent(/c username 1/);
+      // expect list to be unfiltered when search term is removed
+      await user.keyboard('{backspace}{backspace}{backspace}{backspace}');
+      await user.keyboard('{enter}');
+      // get same list again
+      const listUpdated = screen.getAllByRole('listitem');
+      expect(listUpdated.length).toEqual(3);
+    });
   });
 });

--- a/__tests__/helpers/arrays.test.js
+++ b/__tests__/helpers/arrays.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { sortObjectsByParam } from '@/helpers/arrays';
+import { sortObjectsByParam, filterObjectsByParams } from '@/helpers/arrays';
 
 describe('sortObjectsByParam', () => {
   // setup
@@ -30,5 +30,24 @@ describe('sortObjectsByParam', () => {
     expect(result[2].username).toEqual('alpha foo');
     expect(result[3].username).toEqual(null);
     expect(result[4].username).toEqual(undefined);
+  });
+});
+
+describe('filterObjectsByParams', () => {
+  it('filters expected objects from given array', () => {
+    // setup
+    const ary = [
+      { name: 'abcdef', email: 'abc@example.com' }, // name but not email
+      { name: 'ghijk', email: 'def@example.com' }, // email but not name
+      { name: 'lmnop', email: 'lmnop@example.com' },
+    ];
+    const searchTerm = 'def';
+    const params = { name: searchTerm, email: searchTerm };
+    // act
+    const result = filterObjectsByParams(ary, params);
+    // expect
+    expect(result.length).toEqual(2);
+    expect(result[0]).toBe(ary[0]);
+    expect(result[1]).toBe(ary[1]);
   });
 });

--- a/__tests__/helpers/arrays.test.js
+++ b/__tests__/helpers/arrays.test.js
@@ -50,4 +50,21 @@ describe('filterObjectsByParams', () => {
     expect(result[0]).toBe(ary[0]);
     expect(result[1]).toBe(ary[1]);
   });
+
+  it('filter is case insensitive', () => {
+    // setup
+    const ary = [
+      { name: 'abcdef', email: 'abc@example.com' }, // name but not email
+      { name: 'ghijk', email: 'def@example.com' }, // email but not name
+      { name: 'lmnop', email: 'lmnop@example.com' },
+    ];
+    const searchTerm = 'Def';
+    const params = { name: searchTerm, email: searchTerm };
+    // act
+    const result = filterObjectsByParams(ary, params);
+    // expect
+    expect(result.length).toEqual(2);
+    expect(result[0]).toBe(ary[0]);
+    expect(result[1]).toBe(ary[1]);
+  });
 });

--- a/assets/stylesheets/styles.scss
+++ b/assets/stylesheets/styles.scss
@@ -111,3 +111,9 @@
     margin-top: 0;
   }
 }
+
+// Removes the 'X' from Chrome search inputs
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration { display: none; }

--- a/components/ListSearchInput.tsx
+++ b/components/ListSearchInput.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { TextInput } from '@/components/uswds/TextInput';
+import { Button } from '@/components/uswds/Button';
+import { SyntheticEvent } from 'react';
+
+export function ListSearchInput({
+  onSubmit,
+  btnText = 'Search',
+}: {
+  onSubmit: Function;
+  btnText?: string;
+}) {
+  const action = (e: SyntheticEvent) => {
+    e.preventDefault();
+    const formData = new FormData(e.target as HTMLFormElement);
+    const inputValue = formData.get('list-search-field');
+    onSubmit(inputValue);
+  };
+  return (
+    <div className="margin-bottom-2">
+      <form
+        name="list-search-form"
+        className="usa-search usa-search--small"
+        role="search"
+        onSubmit={action}
+      >
+        <label className="usa-sr-only" htmlFor="list-search-field">
+          {btnText}
+        </label>
+        <TextInput type="search" id="list-search-field" />
+        <Button type="submit">{btnText}</Button>
+      </form>
+    </div>
+  );
+}

--- a/components/ListSearchInput.tsx
+++ b/components/ListSearchInput.tsx
@@ -17,7 +17,7 @@ export function ListSearchInput({
     e.preventDefault();
     const formData = new FormData(e.target as HTMLFormElement);
     const inputValue = formData.get('list-search-field');
-    onSubmit(inputValue);
+    onSubmit(inputValue || '');
   };
   return (
     <div className="margin-bottom-2">

--- a/components/ListSearchInput.tsx
+++ b/components/ListSearchInput.tsx
@@ -7,9 +7,11 @@ import { SyntheticEvent } from 'react';
 export function ListSearchInput({
   onSubmit,
   btnText = 'Search',
+  labelText,
 }: {
   onSubmit: Function;
   btnText?: string;
+  labelText?: string;
 }) {
   const action = (e: SyntheticEvent) => {
     e.preventDefault();
@@ -26,7 +28,7 @@ export function ListSearchInput({
         onSubmit={action}
       >
         <label className="usa-sr-only" htmlFor="list-search-field">
-          {btnText}
+          {labelText || btnText}
         </label>
         <TextInput type="search" id="list-search-field" />
         <Button type="submit">{btnText}</Button>

--- a/components/UsersList/UsersList.tsx
+++ b/components/UsersList/UsersList.tsx
@@ -72,9 +72,12 @@ export function UsersList({
 
   return (
     <>
-      <ListSearchInput onSubmit={onSearchAction} />
+      <ListSearchInput
+        onSubmit={onSearchAction}
+        labelText="search the list of users by username"
+      />
       {searchValue && (
-        <div className="margin-bottom-2">
+        <div className="margin-bottom-2" role="region" aria-live="polite">
           <strong>
             {currentUsers.length} user{currentUsers.length === 1 ? '' : 's'}{' '}
             found for "{searchValue}"

--- a/components/UsersList/UsersList.tsx
+++ b/components/UsersList/UsersList.tsx
@@ -69,6 +69,7 @@ export function UsersList({
 
   const modalHeadingId = (name: string) => `removeUserSuccess-${name}`;
   const currentUsers = usersSorted(usersFiltered(users));
+  const usersResultsText = currentUsers.length === 1 ? 'user' : 'users';
 
   return (
     <>
@@ -76,14 +77,20 @@ export function UsersList({
         onSubmit={onSearchAction}
         labelText="search the list of users by username"
       />
-      {searchValue && (
-        <div className="margin-bottom-2" role="region" aria-live="polite">
-          <strong>
-            {currentUsers.length} user{currentUsers.length === 1 ? '' : 's'}{' '}
-            found for "{searchValue}"
-          </strong>
-        </div>
-      )}
+      {/*
+      aria-live region needs to show up on initial page render.
+      More info: https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/
+      */}
+      <div role="region" aria-live="polite">
+        {searchValue && (
+          <div className="margin-bottom-2">
+            <strong>
+              {currentUsers.length} {usersResultsText} found for{' '}
+              {`"${searchValue}"`}
+            </strong>
+          </div>
+        )}
+      </div>
       <GridList>
         {removedUsername && (
           <Modal

--- a/components/UsersList/UsersList.tsx
+++ b/components/UsersList/UsersList.tsx
@@ -6,9 +6,10 @@ import { UsersListItem } from '@/components/UsersList/UsersListItem';
 import { RolesByUser, SpacesBySpaceId } from '@/controllers/controller-types';
 import { UserLogonInfoById } from '@/api/aws/s3-types';
 import { UserObj } from '@/api/cf/cloudfoundry-types';
-import { sortObjectsByParam } from '@/helpers/arrays';
+import { sortObjectsByParam, filterObjectsByParams } from '@/helpers/arrays';
 import { Modal } from '@/components/uswds/Modal';
 import { Alert } from '@/components/uswds/Alert';
+import { ListSearchInput } from '@/components/ListSearchInput';
 
 export function UsersList({
   users,
@@ -24,15 +25,24 @@ export function UsersList({
   orgGuid: string;
 }) {
   const [removedUserGuids, setRemovedUserGuids] = useState([] as string[]);
+  const [searchValue, setSearchValue] = useState('' as string);
 
   function usersSorted(usersList: Array<UserObj>): Array<UserObj> {
     return sortObjectsByParam(usersList, 'username');
   }
 
   function usersFiltered(usersList: Array<UserObj>): Array<UserObj> {
-    return usersList.filter(
+    const filteredForRemoval = usersList.filter(
       (user: UserObj) => !removedUserGuids.find((guid) => guid === user.guid)
     );
+    if (searchValue) {
+      return filterObjectsByParams(filteredForRemoval, {
+        username: searchValue,
+        presentation_name: searchValue,
+      });
+    } else {
+      return filteredForRemoval;
+    }
   }
 
   function removeUserCallback(user: UserObj) {
@@ -49,34 +59,56 @@ export function UsersList({
     setRemovedUsername(user.username);
   }
 
+  const onSearchAction = (value: string) => {
+    if (!value.trim().length) {
+      setSearchValue('');
+    } else {
+      setSearchValue(value.trim());
+    }
+  };
+
   const modalHeadingId = (name: string) => `removeUserSuccess-${name}`;
+  const currentUsers = usersSorted(usersFiltered(users));
 
   return (
-    <GridList>
-      {removedUsername && (
-        <Modal
-          close={closeModal}
-          modalId="removeUserSuccess"
-          headingId={modalHeadingId(removedUsername)}
-        >
-          <Alert type="success" id={modalHeadingId(removedUsername)}>
-            <strong>{removedUsername}</strong> has successfully been removed.
-          </Alert>
-        </Modal>
+    <>
+      <ListSearchInput onSubmit={onSearchAction} />
+      {searchValue && (
+        <div className="margin-bottom-2">
+          <strong>
+            {currentUsers.length} user{currentUsers.length === 1 ? '' : 's'}{' '}
+            found for "{searchValue}"
+          </strong>
+        </div>
       )}
-      {usersSorted(usersFiltered(users)).map((user) => {
-        return (
-          <UsersListItem
-            key={`UsersListItem-${user.guid}`}
-            user={user}
-            roles={roles[user.guid]}
-            spaces={spaces}
-            userLogonInfo={userLogonInfo ? userLogonInfo[user.guid] : undefined}
-            removeUserCallback={removeUserCallback}
-            orgGuid={orgGuid}
-          />
-        );
-      })}
-    </GridList>
+      <GridList>
+        {removedUsername && (
+          <Modal
+            close={closeModal}
+            modalId="removeUserSuccess"
+            headingId={modalHeadingId(removedUsername)}
+          >
+            <Alert type="success" id={modalHeadingId(removedUsername)}>
+              <strong>{removedUsername}</strong> has successfully been removed.
+            </Alert>
+          </Modal>
+        )}
+        {currentUsers.map((user) => {
+          return (
+            <UsersListItem
+              key={`UsersListItem-${user.guid}`}
+              user={user}
+              roles={roles[user.guid]}
+              spaces={spaces}
+              userLogonInfo={
+                userLogonInfo ? userLogonInfo[user.guid] : undefined
+              }
+              removeUserCallback={removeUserCallback}
+              orgGuid={orgGuid}
+            />
+          );
+        })}
+      </GridList>
+    </>
   );
 }

--- a/components/UsersList/UsersList.tsx
+++ b/components/UsersList/UsersList.tsx
@@ -60,7 +60,7 @@ export function UsersList({
   }
 
   const onSearchAction = (value: string) => {
-    if (!value.trim().length) {
+    if (value.trim().length <= 0) {
       setSearchValue('');
     } else {
       setSearchValue(value.trim());

--- a/helpers/arrays.tsx
+++ b/helpers/arrays.tsx
@@ -18,3 +18,17 @@ export function sortObjectsByParam(
     return a[param] < b[param] ? -1 : 1;
   });
 }
+
+export function filterObjectsByParams(
+  ary: Array<any>,
+  params: { [key: string]: string }
+): Array<any> {
+  return ary.filter(function (obj: any) {
+    // find any params that match the search terms
+    return (
+      Object.keys(params).filter((key) =>
+        new RegExp(params[key]).test(obj[key])
+      ).length > 0
+    );
+  });
+}

--- a/helpers/arrays.tsx
+++ b/helpers/arrays.tsx
@@ -27,7 +27,7 @@ export function filterObjectsByParams(
     // find any params that match the search terms
     return (
       Object.keys(params).filter((key) =>
-        new RegExp(params[key]).test(obj[key])
+        new RegExp(params[key], 'i').test(obj[key])
       ).length > 0
     );
   });


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds a search bar to the org members list by username
- Submitting a search term will filter the org members list; clearing the search term will clear the filter
- Adds a reusable filtering helper function 

Because final design for this is pending, UI is minimal in order to demonstrate filtering functionality, and uses OOTB [USWDS search](https://designsystem.digital.gov/components/search/) components. 

### How to test
1. Navigate to an org page: `/orgs/[orgId]`
2. Enter a search term
3. Click 'submit' button (you can also just hit 'Enter' on your keyboard)
4. To clear the filter, remove the search term and re-submit

### Screenshots

#### Default state:

<img width="1125" alt="Screenshot 2024-07-24 at 1 41 08 PM" src="https://github.com/user-attachments/assets/461b06e8-828b-42ee-b8d7-4fc7a8597f89">


#### After search term is entered:

<img width="1113" alt="Screenshot 2024-07-24 at 1 41 25 PM" src="https://github.com/user-attachments/assets/b16c89ce-ebc6-4968-a537-8fdc9d6a9429">

### Related issues

Closes #364

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

Adds a form, prevent submit on default, search terms are handled on client. 
