### PR TITLE
adds explainers for service endpoint overview and service accounts

### DIFF
--- a/docs/explainers/service-accounts-as-users.md
+++ b/docs/explainers/service-accounts-as-users.md
@@ -1,0 +1,34 @@
+# Service accounts and non-human users
+
+## What is a service account?
+
+Cloud.gov allows you to create [service accounts](https://cloud.gov/docs/services/cloud-gov-service-account/) with permission to deploy or monitor applications for use with automations like CI / CD.
+
+### Context
+
+When you create a service account key via the cloud.gov [credentials broker](https://github.com/cloud-gov/uaa-credentials-broker), a new user will be created. This user is created in both UAA and the CF controller API (CAPI). A new user will be created for every service account key that you create.
+
+Service account users are treated by CAPI the same as human users. For this reason, it is difficult to separate out service account users from human users in interfaces except for a couple clues:
+
+- their origin is always uaa (although humans also have this origin until they have logged in)
+- service account users have a GUID for a username, and this username matches the GUID for a service credential binding object
+
+#### Pulling information about service account keys
+
+You can look up your service keys via CLI or API, although keep in mind that not all of these keys may be related to service accounts.
+
+```bash
+cf service-keys [your-service-name]
+
+Getting keys for service instance test-service-account as username@gsa.gov...
+
+name
+test-service-account-key
+test-service-account-key2
+```
+
+While the cf CLI uses /v2 endpoints behind the scenes, it should yield similar results as the following /v3 API request:
+
+```bash
+cf curl "/v3/service_credential_bindings?type=key&service_instance_names=[your-service-name]"
+```

--- a/docs/explainers/service-related-endpoints.md
+++ b/docs/explainers/service-related-endpoints.md
@@ -1,0 +1,41 @@
+# Service related API endpoints
+
+## What are the service related API endpoints?
+
+There are a lot of service related endpoints in the Cloud Foundry controller API (CAPI), which describe everything from registered brokers to service related events. Many of these endpoints are root level, like `/services`, while other times they are embedded in the documentation as paths underneath organizations and applications.
+
+Here is a high level summary of service related concepts and endpoints you may come across in CAPI.
+
+### Service brokers
+
+A service broker is a translation piece that makes it possible for your application to use tools like AWS services, certificate managers, and more. Cloud.gov manages service brokers that it makes available to its users, or users can [create their own brokers](https://cloud.gov/docs/services/intro/#extending-the-marketplace) using the [Open Service Broker API](https://www.openservicebrokerapi.org/).
+
+### Service offering
+
+Service offerings are the product that service brokers are making available. For example, an AWS broker might provide the ability to interact with AWS S3, RDS, and Elasticsearch as distinct service offerings.
+
+The service offering endpoint has information about individual service offerings, like the types of permissions a user would need to operate the service, if the service can be bound to an application, and more.
+
+### Service plan
+
+Service plans are different breakdowns of a service offering and may include information about the cost of operation. For example, a service offering might be "AWS RDS," but within that offering there are different service plans such as "micro-psql" or "medium-mysql."
+
+### Service instance
+
+A service instance is a particular instance of a service plan, typically the thing that's bound to your application. For example, if you attach a database to your application called "user-info," that's a service instance. When service offerings are defined, they may allow you to [query whatever arbitrary parameters about an instance](https://v3-apidocs.cloudfoundry.org/version/3.163.0/#get-parameters-for-a-managed-service-instance) the service offering grants.
+
+The information the API sends back varies depending on whether this is a managed (aka: Cloug.gov created) service, or a user-provided service, but you can expect to find information like the log location, version, and last operation.
+
+### Service credential binding
+
+Service credential bindings give you the credentials you need to connect to a service instance. There are two types: app and key bindings. App bindings are linked to a specific application and the credential information is made available to the app with the VCAP_SERVICES variable.
+
+You may come across a key binding if you are working with a [service account](https://cloud.gov/docs/services/cloud-gov-service-account/). Cloud.gov allows you to create an account with permission to deploy or monitor applications for use with automations like CI / CD. When you create a service account key with the cloud.gov [credentials broker](https://github.com/cloud-gov/uaa-credentials-broker), a new user will be created whose username matches the GUID of a service credential binding. See [the service accounts explainer](./service-accounts-as-users.md) for more info.
+
+## Further reading
+
+- [Open Service Broker API](https://www.openservicebrokerapi.org/)
+- [Cloud documentation for services and user-provided service instances](https://cloud.gov/docs/services/intro/)
+- [Service instance parameters](https://v3-apidocs.cloudfoundry.org/version/3.163.0/#get-parameters-for-a-managed-service-instance)
+- [Cloud.gov service account](https://cloud.gov/docs/services/cloud-gov-service-account/)
+- [Cloud.gov UAA credentials broker](https://github.com/cloud-gov/uaa-credentials-broker)


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds documentation around the many concepts that begin with the word "service" in the API
- provides a little context around what a service account is and how they are treated in CAPI

### Related issues

related to work undertaken in the quest to figure out #363 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [X] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

Hopefully none. I believe that all this information is found in public APIs and public Cloud.gov repositories