### PR TITLE
send slack messages to 18f project channel

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -69,7 +69,7 @@ jobs:
         text: |
           :x: FAILED to deploy cg-ui in development
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
+        channel: '#18f-cloud-web-ui'
         username: ((slack-username))
         icon_url: ((slack-icon-url))
     on_success:
@@ -78,10 +78,9 @@ jobs:
         text: |
           :white_check_mark: Successfully deployed cg-ui in development
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
+        channel: '#18f-cloud-web-ui'
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-
 resources:
   - name: cg-ui
     type: git


### PR DESCRIPTION
## Changes proposed in this pull request:

- ~attempts to use `do` to post to multiple slack channels on deployment failure~
- changes the channel from the platform news channel to the 18F project channel

The dashboard team currently are not cloud.gov staff and do not have access to the channel where deployment failures are reported by the concourse pipeline. Posting to the dashboard team's channel instead will help the dashboard team recognize more quickly when a deployment has failed.

### Related issues

Inspired by debugging #392 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

The 18F team's channel is "public" within slack, meaning that potentially non-cloud staff will be able to observe deployment failures.
