### PR TITLE
changes ci docker node version to match gh action

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The Node version should be updated in the following places:
 1. [.nvmrc](./.nvmrc) which controls the version for cloud builds
 1. [Github workflow containers](./.github/workflows/pull-request.yml) `NODE_VERSION` which controls the version in Github action containers
 1. [package.json](./package.json) under `engines` to specify which version(s) our app works with
+1. [Concourse docker-compose](./ci/docker/docker-compose.yml) and [pipeline](./ci/pipeline.yml)
 
 ## Further reading
 

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: node:20.9-bullseye
+    image: node:20-bullseye
     volumes:
       - ../..:/app
     depends_on:


### PR DESCRIPTION
## Changes proposed in this pull request:

- changes CI docker to match github actions node version (there wasn't a 20.15 available that I saw or I would have used that)
- updates documentation to list the additional place a node version appears in our repo

__I do not actually know if this will work since I cannot test our ci pipeline without merging it, but it ... should?__

### Related issues

Follow on work related to #392 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, this is still a stable / recent release of node
