### PR TITLE
removes husky lines no longer needed in v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Changes proposed in this pull request:

After updating earlier this week (#386 ) a deprecation warning started appearing

- follows steps in https://github.com/typicode/husky/releases/tag/v9.0.1 to migrate to v9

### Related issues

None

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None
