### PR TITLE
Service account name proof-of-concept

### DIFF
--- a/__tests__/components/Username.test.js
+++ b/__tests__/components/Username.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { Username } from '@/components/Username';
+
+describe('Username', () => {
+  it('when given a user, displays the user name', () => {
+    // setup
+    const mockUser = {
+      guid: 'userguid',
+      username: 'User 1',
+    };
+    // act
+    render(<Username user={mockUser} />);
+    const content = screen.getByText('User 1');
+    // assert
+    expect(content).toBeInTheDocument();
+  });
+
+  it('when given a service account user, displays the service account name', () => {
+    // setup
+    const guid = 'cafce0be-62dd-4f02-9770-d546c8714430';
+    const mockUser = {
+      guid: 'userguid',
+      username: guid,
+    };
+    const mockAccount = {
+      guid: guid,
+      name: 'Auditor 1',
+    };
+    // act
+    render(<Username user={mockUser} serviceAccount={mockAccount} />);
+    const auditor = screen.getByText(/Auditor 1/);
+    const svcAcct = screen.getByText(/\[service account\]/);
+    const username = screen.queryByText(guid);
+    // assert
+    expect(auditor).toBeInTheDocument();
+    expect(svcAcct).toBeInTheDocument();
+    expect(username).toBeNull();
+  });
+
+  it('when given a user without a username, displays default text', () => {
+    // setup
+    const mockUser = {
+      guid: 'userguid',
+      username: '',
+    };
+    // act
+    render(<Username user={mockUser} />);
+    const content = screen.getByText('Unnamed user');
+    // assert
+    expect(content).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/UsersList/UsersList.test.js
+++ b/__tests__/components/UsersList/UsersList.test.js
@@ -74,6 +74,7 @@ describe('UsersList', () => {
       <UsersList
         users={mockUsers}
         roles={mockRoles}
+        serviceAccounts={{}}
         spaces={mockSpaces}
         userLoginInfo={mockUserLogonTime}
       />
@@ -95,6 +96,7 @@ describe('UsersList', () => {
         <UsersList
           users={mockUsers}
           roles={mockRoles}
+          serviceAccounts={{}}
           spaces={mockSpaces}
           userLoginInfo={mockUserLogonTime}
         />

--- a/src/api/cf/cloudfoundry-types.ts
+++ b/src/api/cf/cloudfoundry-types.ts
@@ -38,12 +38,32 @@ export interface GetOrgQuotasArgs {
 export interface GetRoleArgs {
   // guids refers to role guids
   guids?: string[];
-  types?: RoleType[];
   include?: Array<'user' | 'space' | 'organization'>;
   organizationGuids?: string[];
   perPage?: string;
   spaceGuids?: string[];
+  types?: RoleType[];
   userGuids?: string[];
+}
+
+export interface GetServiceCredentialBindingsArgs {
+  // guids and names refers to the credential bindings
+  guids?: string[];
+  names?: string[];
+  serviceInstanceGuids?: string[];
+  serviceInstanceNames?: string[];
+  appGuids?: string[];
+  appNames?: string[];
+  servicePlanGuids?: string[];
+  servicePlanNames?: string[];
+  serviceOfferingGuids?: string[];
+  serviceOfferingNames?: string[];
+  type?: 'app' | 'key';
+  include?: Array<'app' | 'service_instance'>;
+  // other arguments not yet implemented
+  // createdAts
+  // updatedAts
+  // labelSelector
 }
 
 export interface GetServiceInstancesArgs {
@@ -148,6 +168,37 @@ export interface RoleObj {
     space: {
       data: {
         guid: string | undefined;
+      };
+    };
+  };
+  links: any;
+}
+
+export interface ServiceCredentialBindingObj {
+  guid: string;
+  name: string;
+  type: 'key' | 'app';
+  last_operation: {
+    // almost identical to last_operation for svc instance but type field differs
+    type: 'create' | 'delete';
+    state: 'initial' | 'in progress' | 'succeeded' | 'failed';
+    description: string;
+    created_at: string;
+    updated_at: string;
+  };
+  created_at: string;
+  updated_at: string;
+  metadata: any;
+  relationships: {
+    service_instance: {
+      data: {
+        guid: string;
+      };
+    };
+    // only for app bindings
+    app?: {
+      data: {
+        guid: string;
       };
     };
   };

--- a/src/api/cf/cloudfoundry.ts
+++ b/src/api/cf/cloudfoundry.ts
@@ -11,6 +11,7 @@ import {
   GetAppArgs,
   GetOrgQuotasArgs,
   GetRoleArgs,
+  GetServiceCredentialBindingsArgs,
   GetServiceInstancesArgs,
   GetServicePlansArgs,
   GetSpaceArgs,
@@ -99,6 +100,13 @@ export async function getRoles({
 }
 
 // SERVICES AND SERVICE RELATED
+
+export async function getServiceCredentialBindings({
+  ...args
+}: GetServiceCredentialBindingsArgs = {}): Promise<Response> {
+  const pathParams = await prepPathParams(args);
+  return await cfRequest('/service_credential_bindings' + pathParams);
+}
 
 // note: there are several other query arguments available for this endpoint which
 // have not been implemented involving subfields, labels, and time ranges

--- a/src/app/orgs/[orgId]/page.tsx
+++ b/src/app/orgs/[orgId]/page.tsx
@@ -17,7 +17,7 @@ export default async function OrgPage({
   params: { orgId: string };
 }) {
   const { payload } = await getOrgPage(params.orgId);
-  const { roles, spaces, users, userLogonInfo } = payload;
+  const { roles, serviceAccounts, spaces, users, userLogonInfo } = payload;
 
   return (
     <>
@@ -37,6 +37,7 @@ export default async function OrgPage({
       <UsersList
         users={users}
         roles={roles}
+        serviceAccounts={serviceAccounts}
         spaces={spaces}
         userLogonInfo={userLogonInfo}
         orgGuid={params.orgId}

--- a/src/app/orgs/[orgId]/users/[userId]/layout.tsx
+++ b/src/app/orgs/[orgId]/users/[userId]/layout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { getUser } from '@/controllers/controllers';
 import Link from 'next/link';
 import { PageHeader } from '@/components/PageHeader';
+import { Username } from '@/components/Username';
 
 export default async function SpaceLayout({
   children,
@@ -13,8 +14,8 @@ export default async function SpaceLayout({
     userId: string;
   };
 }) {
-  const { payload, meta } = await getUser(params.userId);
-
+  const { payload } = await getUser(params.userId);
+  const { user, serviceAccount } = payload;
   return (
     <>
       <div className="desktop:display-flex border-bottom border-accent-warm-light padding-bottom-105">
@@ -25,9 +26,7 @@ export default async function SpaceLayout({
       </div>
       <div className="margin-top-3">
         <PageHeader
-          heading={
-            meta.status === 'success' ? payload.username : 'User name not found'
-          }
+          heading={<Username user={user} serviceAccount={serviceAccount} />}
         />
       </div>
       {children}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -5,7 +5,7 @@ export function PageHeader({
   intro,
   children,
 }: {
-  heading: string;
+  heading: string | React.ReactNode;
   intro?: string;
   children?: React.ReactNode;
 }) {

--- a/src/components/Username.tsx
+++ b/src/components/Username.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import {
+  ServiceCredentialBindingObj,
+  UserObj,
+} from '@/api/cf/cloudfoundry-types';
+
+export function Username({
+  user,
+  serviceAccount,
+}: {
+  user: UserObj;
+  serviceAccount?: ServiceCredentialBindingObj | undefined;
+}) {
+  if (serviceAccount) {
+    return <>{serviceAccount.name} [service account]</>;
+  } else {
+    return <>{user.username ? user.username : 'Unnamed user'}</>;
+  }
+}

--- a/src/components/UsersList/UsersList.tsx
+++ b/src/components/UsersList/UsersList.tsx
@@ -5,7 +5,10 @@ import { GridList } from '@/components/GridList/GridList';
 import { UsersListItem } from '@/components/UsersList/UsersListItem';
 import { RolesByUser, SpacesBySpaceId } from '@/controllers/controller-types';
 import { UserLogonInfoById } from '@/api/aws/s3-types';
-import { UserObj } from '@/api/cf/cloudfoundry-types';
+import {
+  ServiceCredentialBindingObj,
+  UserObj,
+} from '@/api/cf/cloudfoundry-types';
 import { sortObjectsByParam, filterObjectsByParams } from '@/helpers/arrays';
 import { Modal } from '@/components/uswds/Modal';
 import { Alert } from '@/components/uswds/Alert';
@@ -14,12 +17,14 @@ import { ListSearchInput } from '@/components/ListSearchInput';
 export function UsersList({
   users,
   roles,
+  serviceAccounts,
   spaces,
   userLogonInfo,
   orgGuid,
 }: {
   users: Array<UserObj>;
   roles: RolesByUser;
+  serviceAccounts: { [id: string]: ServiceCredentialBindingObj };
   spaces: SpacesBySpaceId;
   userLogonInfo: UserLogonInfoById;
   orgGuid: string;
@@ -109,6 +114,7 @@ export function UsersList({
               key={`UsersListItem-${user.guid}`}
               user={user}
               roles={roles[user.guid]}
+              serviceAccount={serviceAccounts[user.username]}
               spaces={spaces}
               userLogonInfo={
                 userLogonInfo ? userLogonInfo[user.guid] : undefined

--- a/src/components/UsersList/UsersListItem.tsx
+++ b/src/components/UsersList/UsersListItem.tsx
@@ -5,22 +5,26 @@ import {
   SpacesBySpaceId,
 } from '@/controllers/controller-types';
 import { UserLogonInfoDisplay } from '@/controllers/controller-types';
-import { UserObj } from '@/api/cf/cloudfoundry-types';
+import {
+  ServiceCredentialBindingObj,
+  UserObj,
+} from '@/api/cf/cloudfoundry-types';
 import { GridListItem } from '@/components/GridList/GridListItem';
 import { GridListItemTop } from '@/components/GridList/GridListItemTop';
 import { GridListItemBottom } from '@/components/GridList/GridListItemBottom';
 import { GridListItemBottomLeft } from '@/components/GridList/GridListItemBottomLeft';
 import { GridListItemBottomRight } from '@/components/GridList/GridListItemBottomRight';
 import { GridListItemBottomCenter } from '@/components/GridList/GridListItemBottomCenter';
-import { UsersListUsername } from '@/components/UsersList/UsersListUsername';
 import { UsersListOrgRoles } from '@/components/UsersList/UsersListOrgRoles';
 import { UsersListSpaceRoles } from '@/components/UsersList/UsersListSpaceRoles';
 import { UsersListLastLogin } from '@/components/UsersList/UsersListLastLogin';
-import { UsersActionsRemoveFromOrg } from '../UsersActions/UsersActionsRemoveFromOrg';
+import { UsersActionsRemoveFromOrg } from '@/components/UsersActions/UsersActionsRemoveFromOrg';
+import { Username } from '@/components/Username';
 
 export function UsersListItem({
   user,
   roles,
+  serviceAccount,
   spaces,
   userLogonInfo,
   removeUserCallback,
@@ -28,6 +32,7 @@ export function UsersListItem({
 }: {
   user: UserObj;
   roles: RolesByUserItem;
+  serviceAccount: ServiceCredentialBindingObj | undefined;
   spaces: SpacesBySpaceId;
   userLogonInfo: UserLogonInfoDisplay | undefined;
   removeUserCallback?: Function;
@@ -37,7 +42,9 @@ export function UsersListItem({
     <GridListItem>
       <GridListItemTop>
         <div className="margin-bottom-2 tablet:margin-bottom-0">
-          <UsersListUsername username={user.username} />
+          <h2 className="margin-bottom-0 text-break-all font-heading-md">
+            <Username user={user} serviceAccount={serviceAccount} />
+          </h2>
           <UsersActionsRemoveFromOrg
             user={user}
             roles={roles}

--- a/src/components/UsersList/UsersListUsername.tsx
+++ b/src/components/UsersList/UsersListUsername.tsx
@@ -1,9 +1,0 @@
-'use client';
-
-export function UsersListUsername({ username }: { username: string }) {
-  return (
-    <h2 className="margin-bottom-0 text-break-all font-heading-md">
-      {username ? username : 'Unnamed user'}
-    </h2>
-  );
-}

--- a/src/controllers/controller-helpers.ts
+++ b/src/controllers/controller-helpers.ts
@@ -1,5 +1,5 @@
 import { RolesByUser, SpaceRoleMap } from './controller-types';
-import { RoleObj } from '@/api/cf/cloudfoundry-types';
+import { RoleObj, UserObj } from '@/api/cf/cloudfoundry-types';
 import { UserLogonInfoById } from '@/api/aws/s3-types';
 import { cfRequestOptions } from '@/api/cf/cloudfoundry-helpers';
 import { request } from '@/api/api';
@@ -75,6 +75,16 @@ export function filterUserLogonInfo(
     }
   }
   return allowedUserInfo;
+}
+
+// this function makes an assumption about a user based on a number of factors,
+// but we can't actually programmatically tell if this is a non-human without checking
+// against serviceCredentialBindings for the user's guid matching against a credential guid
+export function likelyNonHumanUser(user: UserObj): boolean {
+  const guidRegex = new RegExp(
+    '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+  );
+  return !!(user.origin === 'uaa' && guidRegex.test(user.username));
 }
 
 export async function logDevError(message: string) {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Links users to service credential bindings for those non-human users who are created the service account credentials broker
- Displays the service account key name instead of a GUID
- Primarily focuses on backend / controller functionality to detect non-human users and attempt to look up matching bindings
- Creates a Username component which can swap in a service account name if one is provided, but this element and its appearance are secondary to the purpose of this PR and have not been designed out
- Changes the heading component to accept react nodes rather than simply strings, in case in the future we wish to pass in more complicated HTML such as something which includes an icon

### Screenshots

An example of a key name being displayed instead of a GUID on the org user management page
[alt: a row of the user management with the name test-service-account-key. Service account is written in brackets next to it]
![image](https://github.com/user-attachments/assets/1ac42978-f1c3-4e1f-aa5c-33b928fab64d)

An example of the same key name on the edit space roles page
[alt: the test-service-account-key belongs to one space, jessica.dussault, and has roles of auditor and developer]
![image](https://github.com/user-attachments/assets/53ceb3a3-51ad-45f0-b68c-dff5dffa624b)

An example of a service account key being distinguished from a non-human user with an icon. This is NOT part of this PR, but I wanted to prove out that our header could accommodate that type of functionality if we decide to use something similar.
[alt: the edit space roles page again, but this time instead of service account in brackets next to the name, there is a little wrench icon]

![image](https://github.com/user-attachments/assets/1ca1efac-a693-4873-91c5-5783ef40342e)

### Related issues

related to #363 
related to https://github.com/cloud-gov/cg-ui/pull/385 

### Submitter checklist

- [X] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

I do not believe that the names of service account keys are sensitive information, and the names are already available to anyone with the permissions to query them from the CLI / API, but this PR makes it easier for the casual user to come across them.
