### PR TITLE
adds aliases for jest mocks

### DIFF
--- a/__tests__/api/cf/cloudfoundry.cfRequest.test.js
+++ b/__tests__/api/cf/cloudfoundry.cfRequest.test.js
@@ -4,7 +4,7 @@ import { request } from '@/api/api';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../src/api/api');
+jest.mock('@/api/api');
 /* eslint no-undef: "error" */
 
 // this test is in its own file because of difficulties mocking request and

--- a/__tests__/app/api/session/route.test.js
+++ b/__tests__/app/api/session/route.test.js
@@ -1,12 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
-import { addSession, viewSessions } from '../../../../src/db/session';
+import { addSession, viewSessions } from '@/db/session';
 import { GET, POST } from '@/app/prototype/api/session/route';
 
 /* global jest */
 /* global Promise */
 
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/db/session', () => ({
+jest.mock('@/db/session', () => ({
   addSession: jest.fn(),
   viewSessions: jest.fn(),
 }));

--- a/__tests__/app/api/table/route.test.js
+++ b/__tests__/app/api/table/route.test.js
@@ -1,13 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import {
-  createSessionTable,
-  deleteSessionTable,
-} from '../../../../src/db/session';
+import { createSessionTable, deleteSessionTable } from '@/db/session';
 import { GET, DELETE } from '@/app/prototype/api/table/route';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/db/session', () => ({
+jest.mock('@/db/session', () => ({
   createSessionTable: jest.fn(),
   deleteSessionTable: jest.fn(),
 }));

--- a/__tests__/app/orgs/[orgId]/users/[userId]/actions.test.js
+++ b/__tests__/app/orgs/[orgId]/users/[userId]/actions.test.js
@@ -5,8 +5,8 @@ import { pollForJobCompletion } from '@/controllers/controller-helpers';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../../../src/api/cf/cloudfoundry');
-jest.mock('../../../../../../src/controllers/controller-helpers');
+jest.mock('@/api/cf/cloudfoundry');
+jest.mock('@/controllers/controller-helpers');
 /* eslint no-undef: "error" */
 
 const userGuid = 'fooUserGuid';

--- a/__tests__/app/orgs/[orgId]/users/[userId]/org-roles/actions.test.js
+++ b/__tests__/app/orgs/[orgId]/users/[userId]/org-roles/actions.test.js
@@ -5,8 +5,8 @@ import { pollForJobCompletion } from '@/controllers/controller-helpers';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../../../../src/api/cf/cloudfoundry');
-jest.mock('../../../../../../../src/controllers/controller-helpers');
+jest.mock('@/api/cf/cloudfoundry');
+jest.mock('@/controllers/controller-helpers');
 /* eslint no-undef: "error" */
 
 const userGuid = 'fooUserGuid';

--- a/__tests__/app/orgs/[orgId]/users/add/actions.test.js
+++ b/__tests__/app/orgs/[orgId]/users/add/actions.test.js
@@ -4,7 +4,7 @@ import { addRole } from '@/api/cf/cloudfoundry';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../../../src/api/cf/cloudfoundry');
+jest.mock('@/api/cf/cloudfoundry');
 /* eslint no-undef: "error" */
 
 describe('addUserToOrg', () => {

--- a/__tests__/app/prototype/clientside/page.test.js
+++ b/__tests__/app/prototype/clientside/page.test.js
@@ -13,7 +13,7 @@ import { getUsers } from '@/api/users';
 // because defining the jest global import breaks the mock.
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/api/users', () => ({
+jest.mock('@/api/users', () => ({
   getUsers: jest.fn(),
 }));
 /* eslint no-undef: "error" */

--- a/__tests__/app/prototype/serverside/page.test.js
+++ b/__tests__/app/prototype/serverside/page.test.js
@@ -7,7 +7,7 @@ import Serverside from '@/app/prototype/serverside/page';
 import { getUsers } from '@/api/users';
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/api/users', () => ({
+jest.mock('@/api/users', () => ({
   getUsers: jest.fn(),
 }));
 /* eslint no-undef: "error" */

--- a/__tests__/app/prototype/session/page.test.js
+++ b/__tests__/app/prototype/session/page.test.js
@@ -8,7 +8,7 @@ import { getData } from '@/api/api';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/api/api', () => ({
+jest.mock('@/api/api', () => ({
   addData: jest.fn(),
   getData: jest.fn(),
 }));

--- a/__tests__/app/prototype/users/[id]/page.test.js
+++ b/__tests__/app/prototype/users/[id]/page.test.js
@@ -7,7 +7,7 @@ import UserPage from '@/app/prototype/users/[id]/page';
 import { getUser } from '@/api/users';
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../../src/api/users', () => ({
+jest.mock('@/api/users', () => ({
   getUser: jest.fn(),
 }));
 /* eslint no-undef: "error" */

--- a/__tests__/app/prototype/users/page.test.js
+++ b/__tests__/app/prototype/users/page.test.js
@@ -7,7 +7,7 @@ import UsersPage from '@/app/prototype/users/page';
 import { getUsers } from '@/api/users';
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/api/users', () => ({
+jest.mock('@/api/users', () => ({
   getUsers: jest.fn(),
 }));
 /* eslint no-undef: "error" */

--- a/__tests__/components/OrgActions/OrgActionsAddUser.test.js
+++ b/__tests__/components/OrgActions/OrgActionsAddUser.test.js
@@ -9,7 +9,7 @@ import { addUserToOrg } from '@/app/orgs/[orgId]/users/add/actions';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../src/app/orgs/[orgId]/users/add/actions');
+jest.mock('@/app/orgs/[orgId]/users/add/actions');
 /* eslint no-undef: "error" */
 
 describe('<OrgActionsAddUser />', () => {

--- a/__tests__/components/UsersActions/UsersActionsOrgRoles.test.js
+++ b/__tests__/components/UsersActions/UsersActionsOrgRoles.test.js
@@ -15,8 +15,8 @@ const controllerSuccessResponse = {
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../src/controllers/controllers');
-jest.mock('../../../src/app/orgs/[orgId]/users/[userId]/org-roles/actions');
+jest.mock('@/controllers/controllers');
+jest.mock('@/app/orgs/[orgId]/users/[userId]/org-roles/actions');
 /* eslint no-undef: "error" */
 
 describe('UsersActionsOrgRoles', () => {

--- a/__tests__/components/UsersActions/UsersActionsRemoveFromOrg.test.js
+++ b/__tests__/components/UsersActions/UsersActionsRemoveFromOrg.test.js
@@ -7,7 +7,7 @@ import { UsersActionsRemoveFromOrg } from '@/components/UsersActions/UsersAction
 // import { removeFromOrg } from '@/app/orgs/[orgId]/actions';
 
 /* eslint no-undef: "off" */
-// jest.mock('../../../src/app/orgs/[orgId]/actions', () => ({
+// jest.mock('@/app/orgs/[orgId]/actions', () => ({
 //   removeFromOrg: async () => {
 //     return new Promise((resolve) => {
 //       resolve({

--- a/__tests__/components/UsersActions/UsersActionsSpaceRoles/UsersActionsSpaceRoles.test.js
+++ b/__tests__/components/UsersActions/UsersActionsSpaceRoles/UsersActionsSpaceRoles.test.js
@@ -10,8 +10,8 @@ import { updateSpaceRolesForUser } from '@/app/orgs/[orgId]/users/[userId]/actio
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../../../src/controllers/controllers');
-jest.mock('../../../../src/app/orgs/[orgId]/users/[userId]/actions');
+jest.mock('@/controllers/controllers');
+jest.mock('@/app/orgs/[orgId]/users/[userId]/actions');
 /* eslint no-undef: "error" */
 
 const orgGuid = 'orgGuid1';

--- a/__tests__/controllers/controllers.test.js
+++ b/__tests__/controllers/controllers.test.js
@@ -18,11 +18,11 @@ import { getUserLogonInfo } from '@/api/aws/s3';
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../../src/controllers/controller-helpers', () => ({
+jest.mock('@/controllers/controller-helpers', () => ({
   ...jest.requireActual('../../src/controllers/controller-helpers'),
   pollForJobCompletion: jest.fn(),
 }));
-jest.mock('../../src/api/aws/s3', () => ({
+jest.mock('@/api/aws/s3', () => ({
   getUserLogonInfo: jest.fn(),
 }));
 /* eslint no-undef: "error" */

--- a/__tests__/middleware.test.js
+++ b/__tests__/middleware.test.js
@@ -19,7 +19,7 @@ const mockAuthResponse = {
 
 /* global jest */
 /* eslint no-undef: "off" */
-jest.mock('../src/api/auth', () => ({
+jest.mock('@/api/auth', () => ({
   postToAuthTokenUrl: jest.fn(() => mockAuthResponse),
 }));
 /* eslint no-undef: "error" */

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,9 @@ const config = {
       lines: 60,
     },
   },
-
+  moduleNameMapper: {
+    '@/(.*)': ['<rootDir>/src/$1'],
+  },
   // testEnvironment: node works for api testing, but to test anything needing a browser, like React components, set @jest-environment to jsdom in the file: https://jestjs.io/docs/configuration#testenvironment-string
   testEnvironment: 'node',
   // Add more setup options before each test is run


### PR DESCRIPTION
## Changes proposed in this pull request:

- adds alias path for jest that imitates the ts config alias path
- simplifies tests with deeply nested paths

Let's find out if this works in GH actions!

### Related issues

closes #406 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, changes to tests only