### PR TITLE
Fix: close modal when clicking outside modal

### DIFF
--- a/__tests__/components/uswds/Modal.test.js
+++ b/__tests__/components/uswds/Modal.test.js
@@ -67,4 +67,22 @@ describe('Modal', () => {
     // expect
     expect(closeModal).toHaveBeenCalled();
   });
+
+  it('closes modal when a click happens outside modal', () => {
+    // setup
+    const closeModal = jest.fn();
+    // render
+    render(
+      <Modal modalId="modal-id" headingId="heading-id" close={closeModal}>
+        <p id="heading-id">foo content</p>
+      </Modal>
+    );
+    // expect
+    const modalOverlay = screen.getByTestId(/usa-modal-overlay/);
+    expect(modalOverlay).toBeInTheDocument();
+    // act = press escape key
+    fireEvent.click(modalOverlay);
+    // expect
+    expect(closeModal).toHaveBeenCalled();
+  });
 });

--- a/src/components/uswds/Modal.tsx
+++ b/src/components/uswds/Modal.tsx
@@ -50,14 +50,23 @@ export function Modal({
         close();
       }
     };
+    // close modal when clicking outside the modal
+    const clicked = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target?.className?.match('usa-modal-overlay')) {
+        close();
+      }
+    };
 
     window.addEventListener('keydown', handleTabKeyPress);
     window.addEventListener('keydown', handleEscapeKeyPress);
+    window.addEventListener('click', clicked);
 
     return () => {
       // remove event listeners when component is unmounted
       window.removeEventListener('keydown', handleTabKeyPress);
       window.removeEventListener('keydown', handleEscapeKeyPress);
+      window.removeEventListener('click', clicked);
       // return focus to last focused element before modal was opened
       lastFocusedElement?.focus();
     };
@@ -65,7 +74,7 @@ export function Modal({
 
   return (
     <div className="usa-modal-wrapper is-visible" ref={modalRef}>
-      <div className="usa-modal-overlay">
+      <div className="usa-modal-overlay" data-testid="usa-modal-overlay">
         <div
           className="usa-modal"
           id={modalId}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Closes modal when clicking outside modal

### How to test

1. Navigate to a manage users page (`/orgs/[orgId]`)
2. Click on a "remove" button for a user
3. Click outside the modal
4. Try closing the modal through other methods (escape key, clicking lose icon, etc)

### Related issues

Closes #466 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI only 
