### PR TITLE
Overlay Drawer component

### DIFF
--- a/__tests__/components/OverlayDrawer.test.js
+++ b/__tests__/components/OverlayDrawer.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest, describe, expect, it, beforeAll } from '@jest/globals';
+import { OverlayDrawer } from '@/components/OverlayDrawer';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+describe('<OverlayDrawer />', () => {
+  beforeAll(() => {
+    HTMLDialogElement.prototype.show = jest.fn(function () {
+      this.open = true;
+    });
+
+    HTMLDialogElement.prototype.showModal = jest.fn(function () {
+      this.open = true;
+    });
+
+    HTMLDialogElement.prototype.close = jest.fn(function () {
+      this.open = false;
+    });
+  });
+
+  it('shows dialog content when opened', async () => {
+    // render
+    render(
+      <OverlayDrawer id="overlay-drawer-1" isOpen={true} close={() => {}}>
+        This is the drawer content.
+      </OverlayDrawer>
+    );
+    // assert
+    await waitFor(() => {
+      expect(screen.getByText(/This is the drawer content./i)).toBeVisible();
+    });
+  });
+
+  it('hides dialog content when closed', async () => {
+    // render
+    render(
+      <OverlayDrawer id="overlay-drawer-1" isOpen={false} close={() => {}}>
+        This is the drawer content.
+      </OverlayDrawer>
+    );
+    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByText(/This is the drawer content./i)
+      ).not.toBeVisible();
+    });
+  });
+
+  it('calls the close() prop when using the Escape key to close', async () => {
+    // setup
+    const close = jest.fn();
+    // render
+    render(
+      <OverlayDrawer id="overlay-drawer-1" isOpen={true} close={close}>
+        This is the drawer content.
+      </OverlayDrawer>
+    );
+    // query
+    const content = screen.getByText(/This is the drawer content./);
+    expect(content).toBeInTheDocument();
+    // act = press escape key
+    await waitFor(() => {
+      fireEvent.keyDown(content, {
+        key: 'Escape',
+        code: 'Escape',
+        keyCode: 27,
+        charCode: 27,
+      });
+    });
+    // assert
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/prototype/tables/page.tsx
+++ b/src/app/prototype/tables/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Button } from '@/components/uswds/Button';
 import Link from 'next/link';
 import classnames from 'classnames';
@@ -11,9 +12,10 @@ import { TableRow } from '@/components/uswds/Table/TableRow';
 import { TableCell } from '@/components/uswds/Table/TableCell';
 import { ServiceTag } from '@/components/ServiceTag';
 import { SortButton } from '@/components/SortButton';
+import { OverlayDrawer } from '@/components/OverlayDrawer';
 
 export default function TablePage() {
-  // active color: bg-accent-cool-lightest
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const mockUsers = [
     {
@@ -40,6 +42,25 @@ export default function TablePage() {
 
   return (
     <div className="grid-container padding-bottom-5">
+      <OverlayDrawer
+        id="overlay-drawer-1"
+        isOpen={dialogOpen}
+        close={() => setDialogOpen(false)}
+      >
+        <>
+          This is the drawer content. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+          irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+          fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+          sunt in culpa qui officia deserunt mollit anim id est laborum.
+          <button>trapped 1</button> <button>trapped 2</button>
+        </>
+      </OverlayDrawer>
+
+      <button onClick={() => setDialogOpen(true)}>open dialog</button>
+
       <h2>Table</h2>
 
       <Table

--- a/src/assets/stylesheets/styles.scss
+++ b/src/assets/stylesheets/styles.scss
@@ -255,35 +255,58 @@ $table-sort-active-color: color('blue-cool-5v');
 
 // OverlayDrawer
 
-$timing-dialog: 0.2s;
-
 body:has(dialog.overlayDrawer[open]) {
   overflow: hidden; // prevents scrolling outside of dialog
 }
 
-dialog.overlayDrawer[open] {
+// OverlayDrawer Animations
+// From MDN - Animating Dialogs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#animating_dialogs
+
+$timing-dialog: 0.2s;
+
+// Open state of the dialog
+dialog[open] {
   left: initial;
-  animation: dialog-slide $timing-dialog ease forwards;
+  opacity: 1;
+  transform: translateX( 0 );
 }
 
-dialog.overlayDrawer::backdrop {
-  animation: dialog-backdrop-fade $timing-dialog ease forwards;
+// Closed state of the dialog
+dialog {
+  left: initial;
+  opacity: 0;
+  transform: translateX( 100% );
+  transition:
+    opacity $timing-dialog ease-out,
+    transform $timing-dialog ease-out,
+    overlay $timing-dialog ease-out allow-discrete,
+    display $timing-dialog ease-out allow-discrete;
 }
 
-@keyframes dialog-backdrop-fade {
-  from {
-    background: transparent;
-  }
-  to{
-    background: rgba(0, 0, 0, 0.70);
+// Before-open state
+// Needs to be after the previous dialog[open] rule to take effect,
+// as the specificity is the same
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+    transform: translateX( 100% );
   }
 }
 
-@keyframes dialog-slide {
-  from {
-    right: -100%;
-  }
-  to {
-    right: 0%;
+dialog::backdrop {
+  background-color: rgb(0 0 0 / 0%);
+  transition:
+    display $timing-dialog allow-discrete,
+    overlay $timing-dialog allow-discrete,
+    background-color $timing-dialog;
+}
+
+dialog[open]::backdrop {
+  background-color: rgb(0 0 0 / 70%);
+}
+
+@starting-style {
+  dialog[open]::backdrop {
+    background-color: rgb(0 0 0 / 0%);
   }
 }

--- a/src/assets/stylesheets/styles.scss
+++ b/src/assets/stylesheets/styles.scss
@@ -77,6 +77,8 @@
   // sizing
   $theme-site-margins-width: 2,
 
+  // utilities settings
+
   $display-settings: (
     responsive: true,
   ),
@@ -89,13 +91,24 @@
     responsive: true,
   ),
 
-  // utilities settings
   $text-align-settings: (
     responsive: true
   ),
 
   $background-color-palettes: (
     'palette-color-system-mint-medium' // no trailing comma
+  ),
+
+  $top-palettes: (
+    'palette-units-system-positive'
+  ),
+
+  $right-palettes: (
+    'palette-units-system-positive'
+  ),
+
+  $theme-utility-breakpoints: (
+    'tablet-lg': true,
   ),
 );
 
@@ -237,5 +250,40 @@ $table-sort-active-color: color('blue-cool-5v');
     td:not(:last-child) {
       border-bottom: none;
     }
+  }
+}
+
+// OverlayDrawer
+
+$timing-dialog: 0.2s;
+
+body:has(dialog.overlayDrawer[open]) {
+  overflow: hidden; // prevents scrolling outside of dialog
+}
+
+dialog.overlayDrawer[open] {
+  left: initial;
+  animation: dialog-slide $timing-dialog ease forwards;
+}
+
+dialog.overlayDrawer::backdrop {
+  animation: dialog-backdrop-fade $timing-dialog ease forwards;
+}
+
+@keyframes dialog-backdrop-fade {
+  from {
+    background: transparent;
+  }
+  to{
+    background: rgba(0, 0, 0, 0.70);
+  }
+}
+
+@keyframes dialog-slide {
+  from {
+    right: -100%;
+  }
+  to {
+    right: 0%;
   }
 }

--- a/src/assets/stylesheets/styles.scss
+++ b/src/assets/stylesheets/styles.scss
@@ -265,48 +265,50 @@ body:has(dialog.overlayDrawer[open]) {
 $timing-dialog: 0.2s;
 
 // Open state of the dialog
-dialog[open] {
+dialog.overlayDrawer[open] {
   left: initial;
   opacity: 1;
   transform: translateX( 0 );
+  transition-delay: 0;
 }
 
 // Closed state of the dialog
-dialog {
+dialog.overlayDrawer {
   left: initial;
-  opacity: 0;
+  opacity: 1;
   transform: translateX( 100% );
+  transition-delay: calc( var( $timing-dialog ) / 2);
   transition:
-    opacity $timing-dialog ease-out,
-    transform $timing-dialog ease-out,
-    overlay $timing-dialog ease-out allow-discrete,
-    display $timing-dialog ease-out allow-discrete;
+    transform $timing-dialog ease-in,
+    overlay $timing-dialog ease-in allow-discrete,
+    display $timing-dialog ease-in allow-discrete;
 }
 
 // Before-open state
 // Needs to be after the previous dialog[open] rule to take effect,
 // as the specificity is the same
 @starting-style {
-  dialog[open] {
-    opacity: 0;
+  dialog.overlayDrawer[open] {
     transform: translateX( 100% );
+    transition-delay: 0;
   }
 }
 
-dialog::backdrop {
+dialog.overlayDrawer::backdrop {
   background-color: rgb(0 0 0 / 0%);
+  transition-delay: calc( var( $timing-dialog ) / 2);
   transition:
     display $timing-dialog allow-discrete,
     overlay $timing-dialog allow-discrete,
     background-color $timing-dialog;
 }
 
-dialog[open]::backdrop {
+dialog.overlayDrawer[open]::backdrop {
   background-color: rgb(0 0 0 / 70%);
 }
 
 @starting-style {
-  dialog[open]::backdrop {
+  dialog.overlayDrawer[open]::backdrop {
     background-color: rgb(0 0 0 / 0%);
   }
 }

--- a/src/components/OverlayDrawer.tsx
+++ b/src/components/OverlayDrawer.tsx
@@ -44,6 +44,7 @@ export function OverlayDrawer({
       className="overlayDrawer height-full maxh-none tablet-lg:width-tablet-lg maxw-none padding-y-10 tablet-lg:padding-y-15 padding-right-1 tablet-lg:padding-right-4 padding-left-3 tablet-lg:padding-left-10 bg-accent-warm-light border-accent-cool tablet-lg:border-accent-cool border-left-1 tablet-lg:border-left-105 border-right-0 border-top-0 border-bottom-0"
       ref={dialogRef}
     >
+      <div style={{ overscrollBehavior: 'contain' }}>{children}</div>
       <button
         type="button"
         className="usa-button usa-modal__close position-fixed top-7 right-4"
@@ -53,12 +54,11 @@ export function OverlayDrawer({
         <Image
           unoptimized
           src={closeIcon}
-          alt="close the dialog"
+          alt="Close this dialog"
           width="32"
           height="32"
         />
       </button>
-      <div style={{ overscrollBehavior: 'contain' }}>{children}</div>
     </dialog>
   );
 }

--- a/src/components/OverlayDrawer.tsx
+++ b/src/components/OverlayDrawer.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React, { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import closeIcon from '@/../public/img/uswds/usa-icons/close.svg';
+
+export function OverlayDrawer({
+  children,
+  close, // function for dialog close button that should change the isOpen prop from the parent
+  id,
+  isOpen = false,
+}: {
+  children: React.ReactNode;
+  close: Function;
+  id: string;
+  isOpen: boolean;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (!dialogRef.current) return;
+    if (isOpen) {
+      dialogRef.current.showModal();
+    } else {
+      dialogRef.current.close();
+    }
+
+    const handleEscapeKeyPress = (e: KeyboardEvent) => {
+      // when escape key is used to close dialog, we need to update parent component state
+      if (e.key === 'Escape') {
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleEscapeKeyPress);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscapeKeyPress);
+    };
+  }, [close, isOpen]);
+
+  return (
+    <dialog
+      id={id}
+      className="overlayDrawer height-full maxh-none tablet-lg:width-tablet-lg maxw-none padding-y-10 tablet-lg:padding-y-15 padding-right-1 tablet-lg:padding-right-4 padding-left-3 tablet-lg:padding-left-10 bg-accent-warm-light border-accent-cool tablet-lg:border-accent-cool border-left-1 tablet-lg:border-left-105 border-right-0 border-top-0 border-bottom-0"
+      ref={dialogRef}
+    >
+      <button
+        type="button"
+        className="usa-button usa-modal__close position-fixed top-7 right-4"
+        aria-label="Close this dialog"
+        onClick={() => close()}
+      >
+        <Image
+          unoptimized
+          src={closeIcon}
+          alt="close the dialog"
+          width="32"
+          height="32"
+        />
+      </button>
+      <div style={{ overscrollBehavior: 'contain' }}>{children}</div>
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds an `OverlayDrawer` component

### How to test
1. Spin up a local server (a CF Token is not needed)
1. Navigate to `/prototype/tables`
1. Click the "open dialog" button in the top left corner

### Notes

- Focus trapping is being handled natively by the <dialog> element, so the trapping behavior is a bit different than our current USWDS modal in that it extends focus to browser buttons.

### Screenshots

Open drawer:

![Screenshot 2024-09-05 at 4 33 36 PM](https://github.com/user-attachments/assets/802d8368-13a6-42b2-920b-3e90508b4eb6)

Mobile:

![Screenshot 2024-09-05 at 4 34 44 PM](https://github.com/user-attachments/assets/3c8621bc-89ce-4915-8dba-6d0c3995ec90)

### Related issues

Part of #468 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None, UI element only
