### PR TITLE
Cannandev/org selection close action

### DIFF
--- a/__tests__/components/OrgPicker/OrgPicker.test.js
+++ b/__tests__/components/OrgPicker/OrgPicker.test.js
@@ -23,7 +23,7 @@ describe('<OrgPicker />', () => {
       const user = userEvent.setup();
       render(<OrgPicker />);
       // act
-      const button = screen.getByRole('button', {expanded : false});
+      const button = screen.getByRole('button', { expanded: false });
       await user.click(button);
       // assert
       const content = await screen.findByText('View all organizations');

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { Button } from '@/components/uswds/Button';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import collapseIcon from '@/../public/img/uswds/usa-icons/expand_more.svg';
 import { OrgPickerList } from './OrgPickerList';
@@ -11,10 +11,44 @@ import { OrgPickerFooter } from './OrgPickerFooter';
 
 export function OrgPicker({ single }: { single: Boolean }) {
   const [isOpen, setIsOpen] = useState(false);
+  const orgPickerRef = useRef<HTMLDivElement>(null);
+
+  // Toggle the org picker
   const togglePicker = () => setIsOpen(!isOpen);
 
+  // Close the picker when clicking outside
+  const handleOutsideClick = (e: MouseEvent) => {
+    if (orgPickerRef.current && !orgPickerRef.current.contains(e.target as Node)) {
+      setIsOpen(false);
+    }
+  }
+
+  // Close the picker when pressing the ESC key
+  const handleEscapeKeyPress = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsOpen(false);
+    }
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('mousedown', handleOutsideClick);
+      document.addEventListener('keydown', handleEscapeKeyPress);
+    } else {
+      // Cleanup listeners if org picker is not open
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscapeKeyPress);
+    }
+
+    // Cleanup listeners when the component unmounts
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscapeKeyPress);
+    };
+  }, [isOpen]);
+
   return !single ? (
-    <div className="display-block desktop:display-flex desktop:position-absolute">
+    <div className="display-block desktop:display-flex desktop:position-absolute" ref={orgPickerRef}>
       <span className="usa-label font-body-2xs padding-right-105">
         Current organization:
       </span>

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -47,23 +47,32 @@ export function OrgPicker({ single }: { single: Boolean }) {
     }
   }
 
+  // Add event listners to the org picker
+  const addListeners = () => {
+    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('keydown', handleEscapeKeyPress);
+    document.addEventListener('keydown', handleTabKeyPress);
+  }
+
+  // Remove event listners
+  const removeListeners = () => {
+    // Remove listeners if org picker is not open
+    document.removeEventListener('mousedown', handleOutsideClick);
+    document.removeEventListener('keydown', handleEscapeKeyPress);
+    document.removeEventListener('keydown', handleTabKeyPress);
+  }
+
   useEffect(() => {
     if (isOpen) {
-      document.addEventListener('mousedown', handleOutsideClick);
-      document.addEventListener('keydown', handleEscapeKeyPress);
-      document.addEventListener('keydown', handleTabKeyPress);
+      addListeners();
     } else {
       // Cleanup listeners if org picker is not open
-      document.removeEventListener('mousedown', handleOutsideClick);
-      document.removeEventListener('keydown', handleEscapeKeyPress);
-      document.removeEventListener('keydown', handleTabKeyPress);
+      removeListeners();
     }
 
     // Cleanup listeners when the component unmounts
     return () => {
-      document.removeEventListener('mousedown', handleOutsideClick);
-      document.removeEventListener('keydown', handleEscapeKeyPress);
-      document.removeEventListener('keydown', handleTabKeyPress);
+      removeListeners();
     };
   }, [isOpen]);
 

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -12,13 +12,14 @@ import { OrgPickerFooter } from './OrgPickerFooter';
 export function OrgPicker({ single }: { single: Boolean }) {
   const [isOpen, setIsOpen] = useState(false);
   const orgPickerRef = useRef<HTMLDivElement>(null);
+  const orgsSelectorRef = useRef<HTMLElement>(null);
 
   // Toggle the org picker
   const togglePicker = () => setIsOpen(!isOpen);
 
   // Close the picker when clicking outside
   const handleOutsideClick = (e: MouseEvent) => {
-    if (orgPickerRef.current && !orgPickerRef.current.contains(e.target as Node)) {
+    if (orgsSelectorRef.current && !orgsSelectorRef.current.contains(e.target as Node)) {
       setIsOpen(false);
     }
   }
@@ -73,6 +74,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
         id="orgs-selector"
         className="orgs-selector width-mobile bg-white border border-base-light font-body-2xs padding-x-105 margin-y-1 desktop:margin-y-105"
         aria-expanded={isOpen}
+        ref={orgsSelectorRef}
       >
         <header className="orgs-selector__header display-flex desktop:padding-y-1 flex-align-center">
           <strong className="orgs-selector__current text-bold text-base-darker text-ellipsis margin-right-1 padding-right-1 border-right border-base-light">

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -2,7 +2,6 @@
  * While visually similar to the USWDS Combo box component, this expandable element presents a scrollable list of links. The link at the bottom of the menu directs the user to a page listing all the organizations they can access.
  */
 import React from 'react';
-import { Button } from '@/components/uswds/Button';
 import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import collapseIcon from '@/../public/img/uswds/usa-icons/expand_more.svg';
@@ -11,11 +10,14 @@ import { OrgPickerFooter } from './OrgPickerFooter';
 
 export function OrgPicker({ single }: { single: Boolean }) {
   const [isOpen, setIsOpen] = useState(false);
-  const orgPickerRef = useRef<HTMLDivElement>(null);
   const orgsSelectorRef = useRef<HTMLElement>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
 
   // Toggle the org picker
   const togglePicker = () => setIsOpen(!isOpen);
+
+  // Return focus to toggle button
+  const returnFocus = () => toggleButtonRef.current?.focus();
 
   // Close the picker when clicking outside
   const handleOutsideClick = (e: MouseEvent) => {
@@ -28,19 +30,19 @@ export function OrgPicker({ single }: { single: Boolean }) {
   const handleEscapeKeyPress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       setIsOpen(false);
+      returnFocus();
     }
   }
 
   // Focus back on the toggle button after tabbing through list
   const handleTabKeyPress = (e: KeyboardEvent) => {
-    if (e.key === 'Tab' && isOpen && orgPickerRef.current) {
-      const firstElement = orgPickerRef.current.querySelector('button');
-      const lastElement = orgPickerRef.current.querySelector('footer a');
+    if (e.key === 'Tab' && isOpen && orgsSelectorRef.current) {
+      const lastElement = orgsSelectorRef.current.querySelector('footer a');
 
       if (!e.shiftKey && document.activeElement === lastElement) {
         e.preventDefault();
         setIsOpen(false);
-        firstElement?.focus();
+        returnFocus();
       }
     }
   }
@@ -66,7 +68,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
   }, [isOpen]);
 
   return !single ? (
-    <div className="display-block desktop:display-flex desktop:position-absolute" ref={orgPickerRef}>
+    <div className="display-block desktop:display-flex desktop:position-absolute">
       <span className="usa-label font-body-2xs padding-right-105">
         Current organization:
       </span>
@@ -80,12 +82,12 @@ export function OrgPicker({ single }: { single: Boolean }) {
           <strong className="orgs-selector__current text-bold text-base-darker text-ellipsis margin-right-1 padding-right-1 border-right border-base-light">
             sandbox-gsa-much-longer-name-goes-here-and-is-very-very-long
           </strong>
-          <Button
-            unstyled
-            className="width-5 flex-justify-center"
+          <button
+            className="usa-button usa-button--unstyled width-5 flex-justify-center"
             aria-expanded={isOpen}
             aria-controls="orgs-selector"
             onClick={togglePicker}
+            ref={toggleButtonRef}
           >
             <Image
               unoptimized
@@ -95,7 +97,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
               width={24}
               height={24}
             />
-          </Button>
+          </button>
         </header>
         {isOpen && (
           <>

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -30,20 +30,37 @@ export function OrgPicker({ single }: { single: Boolean }) {
     }
   }
 
+  // Focus back on the toggle button after tabbing through list
+  const handleTabKeyPress = (e: KeyboardEvent) => {
+    if (e.key === 'Tab' && isOpen && orgPickerRef.current) {
+      const firstElement = orgPickerRef.current.querySelector('button');
+      const lastElement = orgPickerRef.current.querySelector('footer a');
+
+      if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        setIsOpen(false);
+        firstElement?.focus();
+      }
+    }
+  }
+
   useEffect(() => {
     if (isOpen) {
       document.addEventListener('mousedown', handleOutsideClick);
       document.addEventListener('keydown', handleEscapeKeyPress);
+      document.addEventListener('keydown', handleTabKeyPress);
     } else {
       // Cleanup listeners if org picker is not open
       document.removeEventListener('mousedown', handleOutsideClick);
       document.removeEventListener('keydown', handleEscapeKeyPress);
+      document.removeEventListener('keydown', handleTabKeyPress);
     }
 
     // Cleanup listeners when the component unmounts
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick);
       document.removeEventListener('keydown', handleEscapeKeyPress);
+      document.removeEventListener('keydown', handleTabKeyPress);
     };
   }, [isOpen]);
 

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -21,10 +21,13 @@ export function OrgPicker({ single }: { single: Boolean }) {
 
   // Close the picker when clicking outside
   const handleOutsideClick = (e: MouseEvent) => {
-    if (orgsSelectorRef.current && !orgsSelectorRef.current.contains(e.target as Node)) {
+    if (
+      orgsSelectorRef.current &&
+      !orgsSelectorRef.current.contains(e.target as Node)
+    ) {
       setIsOpen(false);
     }
-  }
+  };
 
   // Close the picker when pressing the ESC key
   const handleEscapeKeyPress = (e: KeyboardEvent) => {
@@ -32,7 +35,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
       setIsOpen(false);
       returnFocus();
     }
-  }
+  };
 
   // Focus back on the toggle button after tabbing through list
   const handleTabKeyPress = (e: KeyboardEvent) => {
@@ -45,14 +48,14 @@ export function OrgPicker({ single }: { single: Boolean }) {
         returnFocus();
       }
     }
-  }
+  };
 
   // Add event listners to the org picker
   const addListeners = () => {
     document.addEventListener('mousedown', handleOutsideClick);
     document.addEventListener('keydown', handleEscapeKeyPress);
     document.addEventListener('keydown', handleTabKeyPress);
-  }
+  };
 
   // Remove event listners
   const removeListeners = () => {
@@ -60,7 +63,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
     document.removeEventListener('mousedown', handleOutsideClick);
     document.removeEventListener('keydown', handleEscapeKeyPress);
     document.removeEventListener('keydown', handleTabKeyPress);
-  }
+  };
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/OrgPicker/OrgPickerList.tsx
+++ b/src/components/OrgPicker/OrgPickerList.tsx
@@ -6,6 +6,7 @@ export function OrgPickerList() {
       className="orgs-selector__list usa-list usa-list--unstyled maxh-card overflow-x-hidden overflow-y-scroll border-bottom border-top border-base-light"
       tabIndex={0}
       aria-label="Organizations list"
+      role="menu"
     >
       <OrgPickerListItem>another-organization-name-goes-here</OrgPickerListItem>
       <OrgPickerListItem>significantly-shorter-name</OrgPickerListItem>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Close org picker when clicking outside of the list.
- Close org picker when pressing <kbd>Esc</kbd>.
- Close org picker when pressing <kbd>Tab</kbd> _after the last item_ ("View all organizations" link).
  - Focus back on toggle button.

### Related issues

#409 
#464 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

UI changes only.

## Accessibility considerations

I didn't feel comfortable trapping the tab focus _within_ the picker. [I used this pattern as an example](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/).
 
Tabbing past the last link simply closes the picker and focuses back on the toggle. This allows the user to decide if they want to reopen the menu OR go onto the next focusable element on the page. I'm open to discussing 🗣️ 