### PR TITLE
Make org picker functional

### DIFF
--- a/__tests__/components/OrgPicker/OrgPicker.test.js
+++ b/__tests__/components/OrgPicker/OrgPicker.test.js
@@ -3,14 +3,27 @@
  */
 import { describe, expect, it } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line no-unused-vars
+import { usePathname } from 'next/navigation';
 import userEvent from '@testing-library/user-event';
 import { OrgPicker } from '@/components/OrgPicker/OrgPicker';
 
+/* global jest */
+/* eslint no-undef: "off" */
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd'),
+}));
+/* eslint no-undef: "error" */
+
 describe('<OrgPicker />', () => {
+  const mockOrgs = [
+    { name: 'foobar org 1', guid: 'baz' },
+    { name: 'foobar org 2', guid: 'baz2' },
+  ];
   describe('on initial load', () => {
     it('content is collapsed', () => {
       // act
-      render(<OrgPicker />);
+      render(<OrgPicker orgs={mockOrgs} currentOrgId="baz" />);
       // assert
       const content = screen.queryByText('View all organizations');
       expect(content).not.toBeInTheDocument();
@@ -21,13 +34,52 @@ describe('<OrgPicker />', () => {
     it('content expands', async () => {
       // setup
       const user = userEvent.setup();
-      render(<OrgPicker />);
+      render(<OrgPicker orgs={mockOrgs} currentOrgId="baz" />);
       // act
       const button = screen.getByRole('button', { expanded: false });
       await user.click(button);
       // assert
       const content = await screen.findByText('View all organizations');
       expect(content).toBeInTheDocument();
+    });
+  });
+
+  describe('when only one org', () => {
+    it('only shows org name instead of the dropdown', () => {
+      // setup
+      render(<OrgPicker orgs={mockOrgs.slice(0, 1)} currentOrgId="baz" />);
+      // act
+      const orgName = screen.getByText(/foobar org 1/);
+      const button = screen.queryByRole('button');
+      // assert
+      expect(orgName).toBeInTheDocument();
+      expect(button).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when no orgs at all', () => {
+    it('shows nothing', () => {
+      // setup
+      render(<OrgPicker orgs={[]} currentOrgId="baz" />);
+      // act
+      const orgName = screen.queryByText(/foobar org 1/);
+      const button = screen.queryByRole('button');
+      // assert
+      expect(orgName).not.toBeInTheDocument();
+      expect(button).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when no current org', () => {
+    it('shows nothing', () => {
+      // setup
+      render(<OrgPicker orgs={mockOrgs} />);
+      // act
+      const orgName = screen.queryByText(/foobar org 1/);
+      const button = screen.queryByRole('button');
+      // assert
+      expect(orgName).not.toBeInTheDocument();
+      expect(button).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/helpers/text.test.js
+++ b/__tests__/helpers/text.test.js
@@ -4,6 +4,7 @@ import {
   emailIsValid,
   underscoreToText,
   pluralize,
+  newOrgPathname,
 } from '@/helpers/text';
 
 describe('text helpers', () => {
@@ -45,6 +46,57 @@ describe('text helpers', () => {
     it('keeps s off when not plural', () => {
       expect(pluralize('role', 1)).toBe('role');
       expect(pluralize('role', -1)).toBe('role');
+    });
+  });
+
+  describe('newOrgPathname', () => {
+    const newGUID = 'foobar';
+
+    describe('when last GUID starts with an a-z character', () => {
+      it('removes last GUID from pathname', () => {
+        const path =
+          '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd/users/add/b70bd8ff-ed0e-4d11-95c4-cf765202cebd'; // last GUID starts with an a-z character
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar/users/add/');
+      });
+    });
+
+    describe('last GUID starts with an a-z character, but then keeps going with more path sections', () => {
+      it('removes last GUID and beyond from pathname', () => {
+        const path =
+          '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd/users/add/b70bd8ff-ed0e-4d11-95c4-cf765202cebd/keeps-going'; // last GUID starts with an a-z character, but then keeps going with more path sections
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar/users/add/');
+      });
+    });
+
+    describe('when last GUID starts with a digit', () => {
+      it('removes last GUID from pathname', () => {
+        const path =
+          '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd/users/add/470bd8ff-ed0e-4d11-95c4-cf765202cebd/'; // next GUID starts with a digit
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar/users/add/');
+      });
+    });
+
+    describe('when no other GUID but the org GUID', () => {
+      it('just replaces the org guid with new guid', () => {
+        const path = '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd'; // without trailing slash
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar');
+      });
+
+      it('just replaces the org guid with new guid', () => {
+        const path = '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd/'; // with trailing slash
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar/');
+      });
+
+      it('just replaces the org guid with new guid', () => {
+        const path = '/orgs/470bd8ff-ed0e-4d11-95c4-cf765202cebd/users/add'; // with trailing slash
+        const result = newOrgPathname(path, newGUID);
+        expect(result).toEqual('/orgs/foobar/users/add');
+      });
     });
   });
 });

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/app/orgs/[orgId]/layout.tsx
+++ b/src/app/orgs/[orgId]/layout.tsx
@@ -10,9 +10,6 @@ export default async function OrgLayout({
   params: { orgId: string };
 }) {
   const orgsRes = await getOrgs();
-  if (!orgsRes.ok) {
-    return <>orgs not found</>;
-  }
   const orgResJson = await orgsRes.json();
   const orgs = orgResJson.resources;
 

--- a/src/app/orgs/[orgId]/layout.tsx
+++ b/src/app/orgs/[orgId]/layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import Link from 'next/link';
-import { LayoutHeader } from '@/components/LayoutHeader';
-import { getOrg } from '@/controllers/controllers';
+import { OrgPicker } from '@/components/OrgPicker/OrgPicker';
+import { getOrgs } from '@/api/cf/cloudfoundry';
 
 export default async function OrgLayout({
   children,
@@ -10,15 +9,17 @@ export default async function OrgLayout({
   children: React.ReactNode;
   params: { orgId: string };
 }) {
-  const { payload, meta } = await getOrg(params.orgId);
+  const orgsRes = await getOrgs();
+  if (!orgsRes.ok) {
+    return <>orgs not found</>;
+  }
+  const orgResJson = await orgsRes.json();
+  const orgs = orgResJson.resources;
 
   return (
     <>
-      <LayoutHeader>
-        {meta.status === 'success' ? payload.name : 'Org name not found'}
-      </LayoutHeader>
-      <div className="display-block padding-bottom-2">
-        <Link href="/orgs">Back to all organizations</Link>
+      <div className="display-flex flex-column flex-align-end width-full desktop:height-10 margin-top-3">
+        <OrgPicker orgs={orgs} currentOrgId={params.orgId} />
       </div>
       {children}
     </>

--- a/src/app/prototype/design-guide/page.tsx
+++ b/src/app/prototype/design-guide/page.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/uswds/Button';
 import { Banner } from '@/components/uswds/Banner';
 import Checkbox from '@/components/uswds/Checkbox';
 import { useState } from 'react';
-import { OrgPicker } from '@/components/OrgPicker/OrgPicker';
 
 export default function DesignGuidePage() {
   const initialCheckboxes = {
@@ -36,11 +35,6 @@ export default function DesignGuidePage() {
 
       <h2>USA banner</h2>
       <Banner />
-
-      <section className="position-relative padding-y-6">
-        <h2>Org Picker</h2>
-        <OrgPicker single={false} />
-      </section>
 
       <h2>Headers in prose:</h2>
 

--- a/src/assets/stylesheets/styles.scss
+++ b/src/assets/stylesheets/styles.scss
@@ -139,6 +139,13 @@
 // 3. Load any custom SASS
 
 /* Custom utilities classes */
+
+// Flex
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
 // text styling
 .text-capitalize {
   text-transform: capitalize;

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -18,11 +18,9 @@ import { newOrgPathname } from '@/helpers/text';
 export function OrgPicker({
   currentOrgId,
   orgs = [],
-  single = false,
 }: {
   currentOrgId: string;
   orgs?: Array<OrgObj>;
-  single?: Boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const orgsSelectorRef = useRef<HTMLElement>(null);
@@ -99,7 +97,24 @@ export function OrgPicker({
     };
   }, [isOpen]);
 
-  return !single ? (
+  if (orgs.length <= 0 || !currentOrg) {
+    return null;
+  }
+
+  if (orgs.length === 1) {
+    return (
+      <div className="display-block desktop:display-flex">
+        <span className="usa-label font-body-2xs padding-right-105">
+          Current organization:
+        </span>
+        <strong className="text-bold text-base-darker margin-top-3 maxw-mobile">
+          {currentOrg.name}
+        </strong>
+      </div>
+    );
+  }
+
+  return (
     <div className="display-block desktop:display-flex desktop:position-absolute">
       <span className="usa-label font-body-2xs padding-right-105">
         Current organization:
@@ -112,7 +127,7 @@ export function OrgPicker({
       >
         <header className="orgs-selector__header display-flex desktop:padding-y-1 flex-align-center flex-justify">
           <strong className="orgs-selector__current text-bold text-base-darker text-ellipsis margin-right-1 padding-right-1">
-            {currentOrg?.name || 'loading'}
+            {currentOrg.name}
           </strong>
           <button
             className="usa-button usa-button--unstyled width-5 flex-justify-center border-left border-base-light"
@@ -146,15 +161,6 @@ export function OrgPicker({
           </>
         )}
       </nav>
-    </div>
-  ) : (
-    <div className="display-block width-card-lg desktop:display-flex desktop:width-mobile-lg">
-      <span className="usa-label font-body-2xs padding-right-105">
-        Current organization:
-      </span>
-      <strong className="text-bold text-base-darker margin-top-3 maxw-mobile">
-        {currentOrg?.name || 'loading'}
-      </strong>
     </div>
   );
 }

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -121,7 +121,7 @@ export function OrgPicker({
       </span>
       <nav
         id="orgs-selector"
-        className="orgs-selector width-mobile bg-white border border-base-light font-body-2xs padding-x-105 margin-y-1 desktop:margin-y-105"
+        className="orgs-selector width-mobile bg-white border border-base-light font-body-2xs padding-left-105 margin-y-1 desktop:margin-y-105"
         aria-expanded={isOpen}
         ref={orgsSelectorRef}
       >

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -1,71 +1,91 @@
+/* eslint-disable jsx-a11y/role-supports-aria-props */
 /*
  * While visually similar to the USWDS Combo box component, this expandable element presents a scrollable list of links. The link at the bottom of the menu directs the user to a page listing all the organizations they can access.
  */
+'use client';
 import React from 'react';
 import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import collapseIcon from '@/../public/img/uswds/usa-icons/expand_more.svg';
 import { OrgPickerList } from './OrgPickerList';
+import { OrgPickerListItem } from './OrgPickerListItem';
 import { OrgPickerFooter } from './OrgPickerFooter';
+import { OrgObj } from '@/api/cf/cloudfoundry-types';
+import { sortObjectsByParam } from '@/helpers/arrays';
+import { newOrgPathname } from '@/helpers/text';
 
-export function OrgPicker({ single }: { single: Boolean }) {
+export function OrgPicker({
+  currentOrgId,
+  orgs = [],
+  single = false,
+}: {
+  currentOrgId: string;
+  orgs?: Array<OrgObj>;
+  single?: Boolean;
+}) {
   const [isOpen, setIsOpen] = useState(false);
   const orgsSelectorRef = useRef<HTMLElement>(null);
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const currentOrg = orgs.find((org) => org.guid === currentOrgId);
+  const curPathName = usePathname();
+
+  // Get new pathname for another org in the list
+  const orgPathname = (guid: string): string => {
+    return newOrgPathname(curPathName, guid);
+  };
 
   // Toggle the org picker
   const togglePicker = () => setIsOpen(!isOpen);
 
-  // Return focus to toggle button
-  const returnFocus = () => toggleButtonRef.current?.focus();
+  useEffect(() => {
+    // Return focus to toggle button
+    const returnFocus = () => toggleButtonRef.current?.focus();
+    // Close the picker when clicking outside
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (
+        orgsSelectorRef.current &&
+        !orgsSelectorRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
 
-  // Close the picker when clicking outside
-  const handleOutsideClick = (e: MouseEvent) => {
-    if (
-      orgsSelectorRef.current &&
-      !orgsSelectorRef.current.contains(e.target as Node)
-    ) {
-      setIsOpen(false);
-    }
-  };
-
-  // Close the picker when pressing the ESC key
-  const handleEscapeKeyPress = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setIsOpen(false);
-      returnFocus();
-    }
-  };
-
-  // Focus back on the toggle button after tabbing through list
-  const handleTabKeyPress = (e: KeyboardEvent) => {
-    if (e.key === 'Tab' && isOpen && orgsSelectorRef.current) {
-      const lastElement = orgsSelectorRef.current.querySelector('footer a');
-
-      if (!e.shiftKey && document.activeElement === lastElement) {
-        e.preventDefault();
+    // Close the picker when pressing the ESC key
+    const handleEscapeKeyPress = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
         setIsOpen(false);
         returnFocus();
       }
-    }
-  };
+    };
 
-  // Add event listners to the org picker
-  const addListeners = () => {
-    document.addEventListener('mousedown', handleOutsideClick);
-    document.addEventListener('keydown', handleEscapeKeyPress);
-    document.addEventListener('keydown', handleTabKeyPress);
-  };
+    // Focus back on the toggle button after tabbing through list
+    const handleTabKeyPress = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' && isOpen && orgsSelectorRef.current) {
+        const lastElement = orgsSelectorRef.current.querySelector('footer a');
 
-  // Remove event listners
-  const removeListeners = () => {
-    // Remove listeners if org picker is not open
-    document.removeEventListener('mousedown', handleOutsideClick);
-    document.removeEventListener('keydown', handleEscapeKeyPress);
-    document.removeEventListener('keydown', handleTabKeyPress);
-  };
+        if (!e.shiftKey && document.activeElement === lastElement) {
+          e.preventDefault();
+          setIsOpen(false);
+          returnFocus();
+        }
+      }
+    };
+    // Add event listners to the org picker
+    const addListeners = () => {
+      document.addEventListener('mousedown', handleOutsideClick);
+      document.addEventListener('keydown', handleEscapeKeyPress);
+      document.addEventListener('keydown', handleTabKeyPress);
+    };
 
-  useEffect(() => {
+    // Remove event listners
+    const removeListeners = () => {
+      // Remove listeners if org picker is not open
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscapeKeyPress);
+      document.removeEventListener('keydown', handleTabKeyPress);
+    };
+
     if (isOpen) {
       addListeners();
     } else {
@@ -90,12 +110,12 @@ export function OrgPicker({ single }: { single: Boolean }) {
         aria-expanded={isOpen}
         ref={orgsSelectorRef}
       >
-        <header className="orgs-selector__header display-flex desktop:padding-y-1 flex-align-center">
-          <strong className="orgs-selector__current text-bold text-base-darker text-ellipsis margin-right-1 padding-right-1 border-right border-base-light">
-            sandbox-gsa-much-longer-name-goes-here-and-is-very-very-long
+        <header className="orgs-selector__header display-flex desktop:padding-y-1 flex-align-center flex-justify">
+          <strong className="orgs-selector__current text-bold text-base-darker text-ellipsis margin-right-1 padding-right-1">
+            {currentOrg?.name || 'loading'}
           </strong>
           <button
-            className="usa-button usa-button--unstyled width-5 flex-justify-center"
+            className="usa-button usa-button--unstyled width-5 flex-justify-center border-left border-base-light"
             aria-expanded={isOpen}
             aria-controls="orgs-selector"
             onClick={togglePicker}
@@ -113,7 +133,15 @@ export function OrgPicker({ single }: { single: Boolean }) {
         </header>
         {isOpen && (
           <>
-            <OrgPickerList />
+            <OrgPickerList>
+              {sortObjectsByParam(orgs, 'name').map((org) => (
+                <OrgPickerListItem
+                  key={`org-${org.guid}`}
+                  name={org.name}
+                  href={orgPathname(org.guid)}
+                />
+              ))}
+            </OrgPickerList>
             <OrgPickerFooter />
           </>
         )}
@@ -125,7 +153,7 @@ export function OrgPicker({ single }: { single: Boolean }) {
         Current organization:
       </span>
       <strong className="text-bold text-base-darker margin-top-3 maxw-mobile">
-        sandbox-gsa-much-longer-name-goes-here-and-is-very-very-long
+        {currentOrg?.name || 'loading'}
       </strong>
     </div>
   );

--- a/src/components/OrgPicker/OrgPicker.tsx
+++ b/src/components/OrgPicker/OrgPicker.tsx
@@ -121,7 +121,7 @@ export function OrgPicker({
       </span>
       <nav
         id="orgs-selector"
-        className="orgs-selector width-mobile bg-white border border-base-light font-body-2xs padding-left-105 margin-y-1 desktop:margin-y-105"
+        className="orgs-selector width-mobile bg-white border border-base-light font-body-2xs padding-x-105 margin-y-1 desktop:margin-y-105"
         aria-expanded={isOpen}
         ref={orgsSelectorRef}
       >
@@ -130,7 +130,7 @@ export function OrgPicker({
             {currentOrg.name}
           </strong>
           <button
-            className="usa-button usa-button--unstyled width-5 flex-justify-center border-left border-base-light"
+            className="usa-button usa-button--unstyled width-5 flex-justify-center flex-shrink-0 border-left border-base-light padding-left-1"
             aria-expanded={isOpen}
             aria-controls="orgs-selector"
             onClick={togglePicker}

--- a/src/components/OrgPicker/OrgPickerFooter.tsx
+++ b/src/components/OrgPicker/OrgPickerFooter.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export function OrgPickerFooter() {
   return (
     <footer className="text-right text-bold font-sans-2xs text-primary padding-y-105">
-      <Link href="/" className="text-primary">
+      <Link href="/orgs" className="text-primary">
         View all organizations
       </Link>
       <span className="padding-left-05" aria-hidden="true">

--- a/src/components/OrgPicker/OrgPickerList.tsx
+++ b/src/components/OrgPicker/OrgPickerList.tsx
@@ -1,6 +1,6 @@
-import { OrgPickerListItem } from './OrgPickerListItem';
+import React from 'react';
 
-export function OrgPickerList() {
+export function OrgPickerList({ children }: { children: React.ReactNode }) {
   return (
     <ul
       className="orgs-selector__list usa-list usa-list--unstyled maxh-card overflow-x-hidden overflow-y-scroll border-bottom border-top border-base-light"
@@ -8,17 +8,7 @@ export function OrgPickerList() {
       aria-label="Organizations list"
       role="menu"
     >
-      <OrgPickerListItem>another-organization-name-goes-here</OrgPickerListItem>
-      <OrgPickerListItem>significantly-shorter-name</OrgPickerListItem>
-      <OrgPickerListItem>another-organization-name-goes-here</OrgPickerListItem>
-      <OrgPickerListItem>
-        what-happens-when-an-organization-name-is-really-long
-      </OrgPickerListItem>
-      <OrgPickerListItem>significantly-shorter-name</OrgPickerListItem>
-      <OrgPickerListItem>another-shorter-name</OrgPickerListItem>
-      <OrgPickerListItem>
-        hey-that-is-a-really-long-name-for-an-organization
-      </OrgPickerListItem>
+      {children}
     </ul>
   );
 }

--- a/src/components/OrgPicker/OrgPickerListItem.tsx
+++ b/src/components/OrgPicker/OrgPickerListItem.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
 import Link from 'next/link';
 
-export function OrgPickerListItem({ children }: { children: React.ReactNode }) {
+export function OrgPickerListItem({
+  href,
+  name,
+}: {
+  href: string;
+  name: string;
+}) {
   return (
     <li className="padding-y-05">
-      <Link href="/" className="text-primary text-ellipsis">
-        {children}
+      <Link href={href} className="text-primary text-ellipsis">
+        {name}
       </Link>
     </li>
   );

--- a/src/helpers/text.tsx
+++ b/src/helpers/text.tsx
@@ -25,3 +25,27 @@ export function emailIsValid(text: string): boolean {
 export function pluralize(text: string, count: number): string {
   return `${text}${count != 1 && count != -1 ? 's' : ''}`;
 }
+
+export function newOrgPathname(currentPath: string, guid: string): string {
+  // Capture everything past an org GUID,
+  // until you get to another digit (which would be inside the next GUID)
+  const guidRegex =
+    /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/;
+  const match = currentPath.match(
+    /\/orgs\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\/\D+/
+  );
+  if (match && match[0]) {
+    let newPath = match[0];
+    if (newPath !== currentPath) {
+      // This means digits were removed
+      // Since the next GUID could've started with a-zA-Z,
+      // this removes those stragging chars from the previous match.
+      newPath = match[0].replace(/[a-zA-Z]+$/, '');
+    }
+    // replace org GUID with provided one
+    return newPath.replace(guidRegex, guid);
+  } else {
+    // if there's no match, then just replace any GUID with the provided one
+    return currentPath.replace(guidRegex, guid);
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds org picker component to org-related pages and makes it functional

### How to test

1. Log into cloudfoundry through the CLI
2. Start a server using an updated cloud foundry token: `npm run dev-cf`

#### Switching orgs
3. Navigate to an org-related page (like a manage users page)
4. Open org picker and select another org
5. New page should be an equivalent page to previous org

#### Viewing all orgs
1. Navigate to an org-related page (like a manage users page)
2. Open org picker and select "view all organizations"
3. Should navigate you to `/orgs`

### Screenshots

On Manage Users page

![Screenshot 2024-09-25 at 1 16 29 PM](https://github.com/user-attachments/assets/7d98986a-15a2-443d-a4ce-ede26eb5f275)

### Related issues

Closes #410 
Unblocks #408 

### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None
