### PR TITLE
Add basic CSP headers without nonces

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,35 @@
 const path = require('path');
 
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'unsafe-eval' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+`;
+
 module.exports = {
   generateBuildId: async () => {
     // placeholder build id for development
     return '0.0.1';
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
+          },
+        ],
+      },
+    ];
   },
   sassOptions: {
     includePaths: [


### PR DESCRIPTION
## Changes proposed in this pull request:

- Follows Next.js guidance on adding CSP headers via next.config.js

### Related issues

https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy#without-nonces


### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

None
