### PR TITLE
Upgrade success Alerts to role="alert" so they're read consistently

### DIFF
--- a/src/app/prototype/alert/page.tsx
+++ b/src/app/prototype/alert/page.tsx
@@ -1,0 +1,22 @@
+/*
+Test:
+When Alert shows on the page,
+SR reads the message.
+*/
+
+'use client';
+
+import { Alert } from '@/components/uswds/Alert';
+import { useState } from 'react';
+
+export default function AlertPage() {
+  const [alertShown, setAlertShown] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setAlertShown(true)}>show alert</button>
+      <button onClick={() => setAlertShown(false)}>hide alert</button>
+      {alertShown && <Alert type="error">this is an alert!</Alert>}
+    </>
+  );
+}

--- a/src/components/UsersActions/UsersActionsOrgRoles.tsx
+++ b/src/components/UsersActions/UsersActionsOrgRoles.tsx
@@ -153,15 +153,6 @@ export function UsersActionsOrgRoles({
 
   return (
     <>
-      {/* aria-live region needs to show up on initial page render. */}
-      <div
-        role="region"
-        aria-live="polite"
-        aria-atomic={true}
-        className="usa-sr-only"
-      >
-        {actionErrors.join(', ')}
-      </div>
       {actionStatus === 'success' && (
         <Alert type="success">Org roles have been saved!</Alert>
       )}
@@ -226,7 +217,11 @@ export function UsersActionsOrgRoles({
               </Button>
             )}
           </div>
-          {actionStatus === 'pending' && <p>submission in progress...</p>}
+          {actionStatus === 'pending' && (
+            <div role="alert">
+              <p>submission in progress...</p>
+            </div>
+          )}
         </fieldset>
       </form>
     </>

--- a/src/components/UsersActions/UsersActionsSpaceRoles/UsersActionsSpaceRoles.tsx
+++ b/src/components/UsersActions/UsersActionsSpaceRoles/UsersActionsSpaceRoles.tsx
@@ -169,7 +169,11 @@ export function UsersActionsSpaceRoles({
           </Button>
         )}
       </div>
-      {actionStatus === 'pending' && <p>Submission in progress...</p>}
+      {actionStatus === 'pending' && (
+        <div role="alert">
+          <p>submission in progress...</p>
+        </div>
+      )}
     </form>
   );
 }

--- a/src/components/UsersList/UsersList.tsx
+++ b/src/components/UsersList/UsersList.tsx
@@ -166,7 +166,12 @@ export function UsersList({
       aria-live region needs to show up on initial page render.
       More info: https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/
       */}
-      <div role="region" aria-live="assertive" aria-atomic={true}>
+      <div
+        role="region"
+        aria-live="assertive"
+        aria-atomic={true}
+        className="usa-sr-only"
+      >
         {successMsg}
       </div>
       <OverlayDrawer

--- a/src/components/uswds/Alert.tsx
+++ b/src/components/uswds/Alert.tsx
@@ -43,10 +43,7 @@ export function Alert({
   const Heading = headingLevel;
 
   let role = 'region';
-  if (type === 'success') {
-    role = 'status';
-  }
-  if (type === 'error' || type === 'emergency') {
+  if (type === 'error' || type === 'emergency' || type === 'success') {
     role = 'alert';
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upgrade success Alerts to role="alert" so they're read consistently
- Make aria-live region for users list visible only to screen readers
- Include a prototype page (`/prototype/alert`) that demonstrates how Alert components are read when they're added dynamically to a page.

See comments on #531 for further explanation.

### Related issues

Part of research for #531 

### Submitter checklist

- [ ] ~~Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)~~
- [ ] ~~Updated relevant documentation (README, ADRs, explainers, diagrams)~~

## Security considerations

None - UI only
