### PR TITLE
make local key refresh every 15 mins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .env.production.local
 .env.cloud.yml
 script.env
+.token-refresh.pid
 
 # vscode stuff
 .vscode/

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Visit `localhost:3000` to check it out!
 
 Due to developing locally against a "real" environment, we have to play by the rules of the CF CLI. This means that our token expires every 15 minutes or so, and we also need to reauthenticate every 24 hours.
 
-If you start getting 401 errors, restart your application to get a new token. If you haven't logged into the CF CLI on a given day, make sure to reauthenticate following Step 2 above.
+The `dev-cf` command runs a token refresh every 14 and a half minutes, provided you're still authenticated. If you start getting 401 errors, reauthenticate with CF CLI and GSA PreProd as described in step 2, then restart your application to get a new token. 
 
 ### Step 6: Optional stretch goals
 

--- a/token-refresh.sh
+++ b/token-refresh.sh
@@ -6,14 +6,43 @@
 # Note: you must be logged into the cloud foundry CLI
 # for this script to work
 
-file=".env.local"
 
-cf_res=$(cf oauth-token)
-token=${cf_res#* }
+refresh_token() {
+    file=".env.local"
+    cf_res=$(cf oauth-token)
+    token=${cf_res#* }
+    if [ "$token" == "FAILED" ]; then
+        echo "Failed to obtain token"
+        return 1
+    else
+        sed -i '' -e "s/CF_API_TOKEN=.*/CF_API_TOKEN=${token}/" $file
+        echo "$(date): Updated token in ${file}"
+    fi
+}
 
-if [ "$token" == "FAILED" ]; then
-  exit 1
-else
-  sed -i '' -e "s/CF_API_TOKEN=.*/CF_API_TOKEN=${token}/" $file
-  echo "Added token to ${file}"
-fi
+# Function to cleanup background process
+cleanup() {
+    echo "Cleaning up token refresh process..."
+    if [ -f .token-refresh.pid ]; then
+        kill $(cat .token-refresh.pid)
+        rm .token-refresh.pid
+    fi
+    exit 0
+}
+
+# Set up trap to catch Ctrl+C and other termination signals
+trap cleanup SIGINT SIGTERM
+
+# Initial token refresh
+refresh_token
+
+# Start token refresh loop in background
+(
+    while true; do
+        sleep 870  # 14.5 minutes in seconds
+        refresh_token
+    done
+) &
+
+# Store the background process ID
+echo $! > .token-refresh.pid


### PR DESCRIPTION
## Changes proposed in this pull request:
Automatically refreshes the token every 15 mins, provided the user has recently logged into preprod.

@hursey013 is there any reason we shouldn't do this? I can update the README if we want to keep this improvement

### Submitter checklist

- [x] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [x] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations
- no changes to security posture