### PR TITLE
default to v8 of the cf cli

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -222,6 +222,7 @@ resources:
       password: ((dev-cf-password))
       org: cloud-gov
       space: cg-ui
+      cf-cli-version: 8
 
   - name: cf-cli-staging
     type: cf-cli-resource
@@ -231,6 +232,7 @@ resources:
       password: ((staging-cf-password))
       org: cloud-gov
       space: cg-ui
+      cf-cli-version: 8
 
 resource_types:
   - name: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -222,7 +222,7 @@ resources:
       password: ((dev-cf-password))
       org: cloud-gov
       space: cg-ui
-      cf-cli-version: 8
+      cf_cli_version: 8
 
   - name: cf-cli-staging
     type: cf-cli-resource
@@ -232,7 +232,7 @@ resources:
       password: ((staging-cf-password))
       org: cloud-gov
       space: cg-ui
-      cf-cli-version: 8
+      cf_cli_version: 8
 
 resource_types:
   - name: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the cf cli resource to use v8 of the cf cli by default

### Related issues



### Submitter checklist

- [ ] Added logging is not capturing sensitive data and is set to an appropriate level (DEBUG vs INFO etc)
- [ ] Updated relevant documentation (README, ADRs, explainers, diagrams)

## Security considerations

Version 8 of the cf cli should be used because previous versions are deprecated
